### PR TITLE
Add Flask app to serve dashboard locally

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Flask app for Substack Replies dashboard.
+
+Usage:
+  python app.py
+  Then open http://localhost:5000 in your browser.
+"""
+
+import sqlite3
+from pathlib import Path
+from flask import Flask, Response
+
+from dashboard import load_data, load_stats, render_html
+
+app = Flask(__name__)
+DB_PATH = Path(__file__).parent / "replies.db"
+
+
+@app.route("/")
+def index():
+    if not DB_PATH.exists():
+        return Response(
+            "No data found. Run: python scraper.py sync",
+            mimetype="text/plain",
+            status=503,
+        )
+    with sqlite3.connect(DB_PATH) as conn:
+        items = load_data(conn)
+        stats = load_stats(conn)
+    html = render_html(items, stats)
+    return Response(html, mimetype="text/html")
+
+
+if __name__ == "__main__":
+    print("Starting Substack Replies...")
+    print("Open http://localhost:5001 in your browser")
+    app.run(debug=False, port=5001)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+flask


### PR DESCRIPTION
## Summary
- Adds `app.py` — a minimal Flask server that serves the dashboard at `localhost:5001`
- Adds `flask` to `requirements.txt`
- No changes to existing `dashboard.py`, `scraper.py`, or any other files
- Dashboard output is identical to the static HTML version

## Test plan
- [ ] `python app.py` starts the server
- [ ] `localhost:5001` loads the dashboard
- [ ] Output matches `dashboard.html` visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)