### PR TITLE
Sync UX fixes: stop button, persistent log, recheck count fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,40 +17,148 @@ from dashboard import load_data, load_stats, render_html
 
 app = Flask(__name__)
 DB_PATH = Path(__file__).parent / "replies.db"
+_sync_proc = None
 
 
 @app.route("/sync")
 def sync():
+    global _sync_proc
     count = request.args.get("count", 250, type=int)
     def generate():
-        proc = subprocess.Popen(
+        global _sync_proc
+        _sync_proc = subprocess.Popen(
             [sys.executable, "-u", "scraper.py", "sync", "--count", str(count)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=Path(__file__).parent,
             text=True,
         )
-        for line in proc.stdout:
+        for line in _sync_proc.stdout:
             yield f"data: {line.rstrip()}\n\n"
-        proc.wait()
+        _sync_proc.wait()
+        _sync_proc = None
         yield "data: __done__\n\n"
     return Response(generate(), mimetype="text/event-stream",
                     headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"})
 
 
+@app.route("/sync/stop", methods=["POST"])
+def sync_stop():
+    global _sync_proc
+    if _sync_proc and _sync_proc.poll() is None:
+        _sync_proc.terminate()
+        _sync_proc = None
+    return ("", 204)
+
+
 @app.route("/")
 def index():
     if not DB_PATH.exists():
-        return Response(
-            "No data found. Run: python scraper.py sync",
-            mimetype="text/plain",
-            status=503,
-        )
+        return Response(render_empty(), mimetype="text/html")
     with sqlite3.connect(DB_PATH) as conn:
         items = load_data(conn)
         stats = load_stats(conn)
     html = render_html(items, stats)
     return Response(html, mimetype="text/html")
+
+
+def render_empty():
+    return """<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Substack Replies</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         background: #f5f4f0; color: #1a1a1a; padding: 24px; }
+  .header { max-width: 720px; margin: 0 auto 20px; }
+  h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 4px; }
+  .subtitle { color: #666; font-size: 0.9rem; margin-bottom: 16px; }
+  .sync-row { display: flex; align-items: center; gap: 10px; margin-top: 14px; }
+  .sync-btn { background: #ff3300; color: white; border: none; border-radius: 6px;
+               padding: 6px 16px; font-size: 0.85rem; font-weight: 600; cursor: pointer; }
+  .sync-btn:disabled { background: #ccc; cursor: default; }
+  .sync-status { font-size: 0.82rem; color: #888; }
+  .sync-log { margin-top: 10px; padding: 10px; background: #1a1a1a; color: #ccc;
+               font-size: 0.75rem; border-radius: 6px; max-height: 300px; overflow-y: auto;
+               white-space: pre-wrap; max-width: 720px; }
+</style></head>
+<body>
+  <div class="header">
+    <h1>Substack Replies</h1>
+    <div class="subtitle">No data yet — run a sync to get started.</div>
+    <div class="sync-row">
+      <label style="font-size:0.82rem; color:#666;">New replies to sync:</label>
+      <select id="sync-count" style="font-size:0.82rem; padding:4px 6px; border-radius:4px; border:1px solid #ccc;">
+        <option value="25" selected>25</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+        <option value="200">200</option>
+        <option value="250">250</option>
+      </select>
+      <button class="sync-btn" id="sync-btn" onclick="startSync()">Sync</button>
+      <button class="sync-btn" id="stop-btn" onclick="stopSync()" style="display:none; background:#888;">Stop</button>
+      <span class="sync-status" id="sync-status"></span>
+    </div>
+    <pre class="sync-log" id="sync-log" style="display:none"></pre>
+    <div id="last-sync-log-wrap" style="display:none; margin-top:6px;">
+      <button onclick="toggleLastLog(this)" style="background:none; border:none; cursor:pointer; font-size:0.8rem; color:#888; padding:0;">▶ Last sync log</button>
+      <pre class="sync-log" id="last-sync-log" style="display:none; margin-top:4px;"></pre>
+    </div>
+  </div>
+  <script>
+    (function() {
+      const saved = localStorage.getItem('lastSyncLog');
+      if (saved) {
+        const wrap = document.getElementById('last-sync-log-wrap');
+        const pre = document.getElementById('last-sync-log');
+        pre.textContent = saved;
+        wrap.style.display = '';
+      }
+    })();
+    function toggleLastLog(btn) {
+      const pre = document.getElementById('last-sync-log');
+      const open = pre.style.display === 'block';
+      pre.style.display = open ? 'none' : 'block';
+      btn.textContent = open ? '▶ Last sync log' : '▼ Last sync log';
+    }
+    let _es = null;
+    function startSync() {
+      const btn = document.getElementById('sync-btn');
+      const stopBtn = document.getElementById('stop-btn');
+      const count = document.getElementById('sync-count').value;
+      const status = document.getElementById('sync-status');
+      const log = document.getElementById('sync-log');
+      btn.style.display = 'none';
+      stopBtn.style.display = '';
+      status.textContent = 'Starting…';
+      log.textContent = '';
+      log.style.display = 'block';
+      _es = new EventSource('/sync?count=' + count);
+      _es.onmessage = function(e) {
+        if (e.data === '__done__') {
+          _es.close(); _es = null;
+          localStorage.setItem('lastSyncLog', log.textContent);
+          status.textContent = 'Done — reloading…';
+          setTimeout(() => window.location.reload(), 1500);
+          return;
+        }
+        log.textContent += e.data + '\\n';
+        log.scrollTop = log.scrollHeight;
+        status.textContent = e.data;
+      };
+      _es.onerror = function() {
+        _es.close(); _es = null;
+        btn.style.display = ''; stopBtn.style.display = 'none';
+        status.textContent = 'Error — check terminal';
+      };
+    }
+    function stopSync() {
+      if (_es) { _es.close(); _es = null; }
+      fetch('/sync/stop', {method: 'POST'});
+      document.getElementById('sync-btn').style.display = '';
+      document.getElementById('stop-btn').style.display = 'none';
+      document.getElementById('sync-status').textContent = 'Stopped.';
+    }
+  </script>
+</body></html>"""
 
 
 if __name__ == "__main__":

--- a/check.py
+++ b/check.py
@@ -91,7 +91,7 @@ def check_dashboard_loads_data():
         stats = dashboard.load_stats(conn)
     assert isinstance(items, list), "load_data did not return a list"
     assert "activity_items" in stats, "load_stats missing activity_items"
-    assert "last_sync" in stats, "load_stats missing last_sync"
+    assert "synced_up_to" in stats, "load_stats missing synced_up_to"
     return f"{len(items)} items needing response"
 
 def check_dashboard_renders():

--- a/dashboard.py
+++ b/dashboard.py
@@ -443,16 +443,21 @@ def render_html(items, stats):
     <div class="sync-row">
       <label style="font-size:0.82rem; color:#666;">New replies to sync:</label>
       <select id="sync-count" style="font-size:0.82rem; padding:4px 6px; border-radius:4px; border:1px solid #ccc;">
-        <option value="25">25</option>
+        <option value="25" selected>25</option>
         <option value="50">50</option>
         <option value="100">100</option>
         <option value="200">200</option>
-        <option value="250" selected>250</option>
+        <option value="250">250</option>
       </select>
       <button class="sync-btn" id="sync-btn" onclick="startSync()">Sync</button>
+      <button class="sync-btn" id="stop-btn" onclick="stopSync()" style="display:none; background:#888;">Stop</button>
       <span class="sync-status" id="sync-status"></span>
     </div>
     <pre class="sync-log" id="sync-log" style="display:none"></pre>
+    <div id="last-sync-log-wrap" style="display:none; margin-top:6px;">
+      <button onclick="toggleLastLog(this)" style="background:none; border:none; cursor:pointer; font-size:0.8rem; color:#888; padding:0;">▶ Last sync log</button>
+      <pre class="sync-log" id="last-sync-log" style="display:none; margin-top:4px;"></pre>
+    </div>
   </div>
 
   <div class="intro">
@@ -620,36 +625,67 @@ def render_html(items, stats):
     updateCount();
     updateDoneCount();
 
+    // Restore last sync log if present
+    (function() {{
+      const saved = localStorage.getItem('lastSyncLog');
+      if (saved) {{
+        const wrap = document.getElementById('last-sync-log-wrap');
+        const pre = document.getElementById('last-sync-log');
+        pre.textContent = saved;
+        wrap.style.display = '';
+      }}
+    }})();
+
+    function toggleLastLog(btn) {{
+      const pre = document.getElementById('last-sync-log');
+      const open = pre.style.display === 'block';
+      pre.style.display = open ? 'none' : 'block';
+      btn.textContent = open ? '▶ Last sync log' : '▼ Last sync log';
+    }}
+
+    let _es = null;
+
     function startSync() {{
       const btn = document.getElementById('sync-btn');
+      const stopBtn = document.getElementById('stop-btn');
       const count = document.getElementById('sync-count').value;
       const status = document.getElementById('sync-status');
       const log = document.getElementById('sync-log');
-      btn.disabled = true;
-      btn.textContent = 'Syncing…';
+      btn.style.display = 'none';
+      stopBtn.style.display = '';
       status.textContent = 'Starting…';
       log.textContent = '';
       log.style.display = 'block';
 
-      const es = new EventSource('/sync?count=' + count);
-      es.onmessage = function(e) {{
+      _es = new EventSource('/sync?count=' + count);
+      _es.onmessage = function(e) {{
         if (e.data === '__done__') {{
-          es.close();
-          btn.disabled = false;
-          btn.textContent = 'Sync';
-          status.textContent = 'Done — reload to see new replies';
+          _es.close();
+          _es = null;
+          localStorage.setItem('lastSyncLog', log.textContent);
+          status.textContent = 'Done — reloading…';
+          setTimeout(() => window.location.reload(), 1500);
           return;
         }}
         log.textContent += e.data + '\\n';
         log.scrollTop = log.scrollHeight;
         status.textContent = e.data;
       }};
-      es.onerror = function() {{
-        es.close();
-        btn.disabled = false;
-        btn.textContent = 'Sync';
+      _es.onerror = function() {{
+        _es.close();
+        _es = null;
+        btn.style.display = '';
+        stopBtn.style.display = 'none';
         status.textContent = 'Error — check terminal';
       }};
+    }}
+
+    function stopSync() {{
+      if (_es) {{ _es.close(); _es = null; }}
+      fetch('/sync/stop', {{method: 'POST'}});
+      document.getElementById('sync-btn').style.display = '';
+      document.getElementById('stop-btn').style.display = 'none';
+      document.getElementById('sync-status').textContent = 'Stopped.';
     }}
   </script>
 </body>

--- a/scraper.py
+++ b/scraper.py
@@ -215,8 +215,8 @@ def recheck_unresponded(conn):
         key = (subdomain, post_id)
         groups.setdefault(key, []).append((item_id, comment_id))
 
-    print(f"{ts()} Rechecking {len(rows)} items across {len(groups)} posts...")
-    still_unresponded = 0
+    print(f"{ts()} Rechecking {len(rows)} items...")
+    still_unresponded = skip_count
     newly_responded = 0
 
     for (subdomain, post_id), items in groups.items():


### PR DESCRIPTION
## Summary
- Add stop button to cancel an in-progress sync
- Persist sync log to localStorage so it's visible (collapsed) after page reload
- Default sync count changed from 250 to 25
- Fix recheck output: skipped items (note replies / no URL) now count toward `still_unresponded` so the total matches items fetched
- Remove misleading "across N posts" from recheck log line
- Fix `check.py`: update expected key from `last_sync` to `synced_up_to`

## Test plan
- [ ] Run `python check.py` — all 9 checks pass
- [ ] Start app, verify 25 is selected by default
- [ ] Run a sync, verify log appears during sync then collapses after reload
- [ ] Verify stop button appears during sync and cancels it

🤖 Generated with [Claude Code](https://claude.com/claude-code)