### PR TITLE
Fix search auto-open and add clickable commenter names (#21, #22)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -28,15 +28,20 @@ def load_thread(conn, reply_id):
         return []
     placeholders = ",".join("?" * len(ancestor_ids))
     rows = conn.execute(
-        f"SELECT id, name, body, post_url FROM comments WHERE id IN ({placeholders})", ancestor_ids
+        f"SELECT id, name, body, post_url, handle FROM comments WHERE id IN ({placeholders})", ancestor_ids
     ).fetchall()
     by_id = {r[0]: r for r in rows}
     result = []
     for i in ancestor_ids:
         if i not in by_id:
             continue
-        _, name, body, post_url = by_id[i]
-        link = f"{post_url.rstrip('/')}/comment/{i}" if post_url else None
+        _, name, body, post_url, handle = by_id[i]
+        if post_url:
+            link = f"{post_url.rstrip('/')}/comment/{i}"
+        elif handle:
+            link = f"https://substack.com/@{handle}/note/c-{i}"
+        else:
+            link = None
         result.append({"id": i, "name": name or "?", "body": body or "", "link": link})
     return result
 


### PR DESCRIPTION
## Summary
- **#21**: Removes the two lines in `filterByName` that auto-expanded liked/responded sections when a search matched items in them. Sections now stay collapsed; counts update but user expands manually. Arrow direction stays correct since we no longer touch `display` programmatically.
- **#22**: The `handle` field has been stored on items since PR #12 but was never wired up. Commenter names in reply cards are now clickable links to `https://substack.com/@{handle}` when a handle is available, matching the same style as thread context name links.

## Test plan
- [ ] Search by a name that has liked/responded matches — sections should stay collapsed
- [ ] Arrow direction on liked/responded toggles should stay `▶` after a search
- [ ] Commenter names in reply cards should be clickable and open the Substack profile in a new tab
- [ ] Commenter names with no handle (Anonymous) should remain plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)