### PR TITLE
Smart pub sync: only re-fetch posts where comment count changed

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -765,23 +765,44 @@ def load_posts_to_target(conn, pub_subdomain, target=25):
 
 def refresh_post_comments(conn, pub_subdomain):
     """
-    Re-fetch comments for all loaded posts in a publication.
-    Updates existing comment records with fresh data (picks up new reactions/replies).
+    Smart sync: fetch fresh comment counts for all posts, then only re-fetch
+    comments for posts where the count has changed since last sync.
     """
-    posts = conn.execute("""
-        SELECT id, title, canonical_url FROM posts
+    loaded = conn.execute("""
+        SELECT id, title, canonical_url, comment_count FROM posts
         WHERE pub_subdomain=? ORDER BY post_date DESC
     """, (pub_subdomain,)).fetchall()
 
-    if not posts:
+    if not loaded:
         print(f"{ts()} No posts loaded for {pub_subdomain}.")
         return
 
-    print(f"{ts()} Refreshing {len(posts)} posts in {pub_subdomain}...")
-    for post_id, post_title, post_url in posts:
+    stored_counts = {row[0]: (row[1], row[2], row[3]) for row in loaded}
+
+    # Fetch fresh post list to get current comment counts (a few paginated calls)
+    print(f"{ts()} Checking comment counts for {len(loaded)} posts in {pub_subdomain}...")
+    fresh_posts = fetch_all_posts(pub_subdomain)
+    fresh_counts = {p["id"]: p.get("comment_count", 0) for p in fresh_posts}
+
+    changed = []
+    for post_id, (post_title, post_url, stored_count) in stored_counts.items():
+        fresh_count = fresh_counts.get(post_id)
+        if fresh_count is None:
+            continue  # post no longer in API (deleted/draft)
+        if fresh_count != stored_count:
+            changed.append((post_id, post_title, post_url, stored_count, fresh_count))
+
+    if not changed:
+        print(f"{ts()} All up to date — no comment count changes detected.")
+        return
+
+    print(f"{ts()} {len(changed)} post(s) have new activity — refreshing comments...")
+    for post_id, post_title, post_url, old_count, new_count in changed:
         try:
             comments = fetch_post_comments(pub_subdomain, post_id)
             flat = flatten_comments(comments)
+
+            new_from_others = 0
             for c in flat:
                 existing = conn.execute("SELECT id FROM comments WHERE id=?", (c["id"],)).fetchone()
                 if existing:
@@ -790,13 +811,22 @@ def refresh_post_comments(conn, pub_subdomain):
                 else:
                     _store_comment(conn, c, pub_subdomain=pub_subdomain, post_id=post_id,
                                    post_title=post_title, post_url=post_url)
+                    if c.get("user_id") != USER_ID:
+                        new_from_others += 1
+
+            if new_from_others:
+                print(f"{ts()}   \"{post_title or post_id}\": {new_from_others} new comment(s) from others")
+            else:
+                print(f"{ts()}   \"{post_title or post_id}\": count changed (your own reply or edit) — nothing new to respond to")
+
+            # Update stored comment count
+            conn.execute("UPDATE posts SET comment_count=? WHERE id=?", (new_count, post_id))
             conn.commit()
-            print(f"{ts()}   \"{post_title or post_id}\": {len(flat)} comments")
             time.sleep(0.5)
         except Exception as e:
             print(f"{ts()}   warning: couldn't refresh post {post_id}: {e}")
 
-    print(f"{ts()} Post refresh complete.")
+    print(f"{ts()} Sync complete.")
 
 
 # ── Report ────────────────────────────────────────────────────────────────────

--- a/test_smart_sync.py
+++ b/test_smart_sync.py
@@ -1,0 +1,180 @@
+"""
+Tests for refresh_post_comments smart sync logic.
+Mocks fetch_all_posts and fetch_post_comments — no real API calls.
+"""
+import sqlite3
+import unittest
+from unittest.mock import patch
+from io import StringIO
+import sys
+
+# We need config values before importing scraper
+import config
+import scraper
+
+def make_db():
+    """Create an in-memory DB with the required schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE posts (
+            id INTEGER PRIMARY KEY,
+            pub_subdomain TEXT,
+            title TEXT,
+            slug TEXT,
+            canonical_url TEXT,
+            post_date TEXT,
+            comment_count INTEGER
+        );
+        CREATE TABLE comments (
+            id INTEGER PRIMARY KEY,
+            pub_subdomain TEXT,
+            post_id INTEGER,
+            post_title TEXT,
+            post_url TEXT,
+            parent_id INTEGER,
+            ancestor_path TEXT,
+            user_id INTEGER,
+            handle TEXT,
+            name TEXT,
+            body TEXT,
+            date TEXT,
+            raw_json TEXT
+        );
+    """)
+    return conn
+
+def seed_post(conn, post_id, title, comment_count):
+    conn.execute(
+        "INSERT INTO posts (id, pub_subdomain, title, canonical_url, comment_count) VALUES (?,?,?,?,?)",
+        (post_id, "testpub", title, f"https://testpub.substack.com/p/{post_id}", comment_count)
+    )
+
+def seed_comment(conn, comment_id, post_id, user_id, body="hello"):
+    conn.execute(
+        "INSERT INTO comments (id, user_id, body, post_id, pub_subdomain, raw_json) VALUES (?,?,?,?,?,?)",
+        (comment_id, user_id, body, post_id, "testpub", "{}")
+    )
+
+def capture_output(fn):
+    """Run fn() and return stdout as a string."""
+    buf = StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        fn()
+    finally:
+        sys.stdout = old
+    return buf.getvalue()
+
+OTHER_USER = 99999
+MY_USER = config.USER_ID
+
+class TestSmartSync(unittest.TestCase):
+
+    def test_no_changes(self):
+        """All comment counts match — nothing should be fetched."""
+        conn = make_db()
+        seed_post(conn, 1, "Post One", 3)
+
+        fresh_posts = [{"id": 1, "comment_count": 3}]
+        with patch.object(scraper, "fetch_all_posts", return_value=fresh_posts):
+            output = capture_output(lambda: scraper.refresh_post_comments(conn, "testpub"))
+
+        self.assertIn("All up to date", output)
+        # fetch_post_comments should never have been called
+        self.assertNotIn("new comment", output)
+
+    def test_new_comment_from_other(self):
+        """Count increased, new comment is from someone else."""
+        conn = make_db()
+        seed_post(conn, 1, "Post One", 2)
+        seed_comment(conn, 101, 1, OTHER_USER, "old comment")
+
+        fresh_posts = [{"id": 1, "comment_count": 3}]
+        # New comment (id=102) from another user, not in DB yet
+        fresh_comments = [
+            {"id": 101, "user_id": OTHER_USER, "body": "old comment", "name": "Alice",
+             "handle": "alice", "date": "2026-01-01", "ancestor_path": None},
+            {"id": 102, "user_id": OTHER_USER, "body": "brand new!", "name": "Bob",
+             "handle": "bob", "date": "2026-04-07", "ancestor_path": None},
+        ]
+        with patch.object(scraper, "fetch_all_posts", return_value=fresh_posts), \
+             patch.object(scraper, "fetch_post_comments", return_value=fresh_comments), \
+             patch.object(scraper, "flatten_comments", return_value=fresh_comments):
+            output = capture_output(lambda: scraper.refresh_post_comments(conn, "testpub"))
+
+        self.assertIn("1 new comment(s) from others", output)
+        self.assertIn("Sync complete", output)
+        # Stored count updated
+        new_count = conn.execute("SELECT comment_count FROM posts WHERE id=1").fetchone()[0]
+        self.assertEqual(new_count, 3)
+
+    def test_count_changed_by_own_reply(self):
+        """Count increased, but new comment is from the user themselves."""
+        conn = make_db()
+        seed_post(conn, 1, "Post One", 2)
+        seed_comment(conn, 101, 1, OTHER_USER, "their comment")
+
+        fresh_posts = [{"id": 1, "comment_count": 3}]
+        fresh_comments = [
+            {"id": 101, "user_id": OTHER_USER, "body": "their comment", "name": "Alice",
+             "handle": "alice", "date": "2026-01-01", "ancestor_path": None},
+            {"id": 102, "user_id": MY_USER, "body": "my reply", "name": "Alyssa",
+             "handle": "alyssa", "date": "2026-04-07", "ancestor_path": None},
+        ]
+        with patch.object(scraper, "fetch_all_posts", return_value=fresh_posts), \
+             patch.object(scraper, "fetch_post_comments", return_value=fresh_comments), \
+             patch.object(scraper, "flatten_comments", return_value=fresh_comments):
+            output = capture_output(lambda: scraper.refresh_post_comments(conn, "testpub"))
+
+        self.assertIn("your own reply or edit", output)
+        self.assertNotIn("new comment(s) from others", output)
+
+    def test_multiple_posts_mixed(self):
+        """One post unchanged, one with new comment, one with own reply."""
+        conn = make_db()
+        seed_post(conn, 1, "Unchanged", 5)
+        seed_post(conn, 2, "New Comment", 2)
+        seed_post(conn, 3, "Own Reply", 2)
+
+        fresh_posts = [
+            {"id": 1, "comment_count": 5},  # unchanged
+            {"id": 2, "comment_count": 3},  # new comment from other
+            {"id": 3, "comment_count": 3},  # own reply
+        ]
+        comments_post2 = [
+            {"id": 201, "user_id": OTHER_USER, "body": "new!", "name": "X",
+             "handle": "x", "date": "2026-04-07", "ancestor_path": None},
+        ]
+        comments_post3 = [
+            {"id": 301, "user_id": MY_USER, "body": "my reply", "name": "Alyssa",
+             "handle": "alyssa", "date": "2026-04-07", "ancestor_path": None},
+        ]
+
+        def mock_fetch_posts(subdomain):
+            return fresh_posts
+
+        def mock_fetch_comments(subdomain, post_id):
+            return comments_post2 if post_id == 2 else comments_post3
+
+        def mock_flatten(comments):
+            return comments
+
+        with patch.object(scraper, "fetch_all_posts", side_effect=mock_fetch_posts), \
+             patch.object(scraper, "fetch_post_comments", side_effect=mock_fetch_comments), \
+             patch.object(scraper, "flatten_comments", side_effect=mock_flatten):
+            output = capture_output(lambda: scraper.refresh_post_comments(conn, "testpub"))
+
+        self.assertIn("2 post(s) have new activity", output)
+        self.assertIn("1 new comment(s) from others", output)
+        self.assertIn("your own reply or edit", output)
+
+    def test_no_posts_loaded(self):
+        """DB has no posts — should say so and return."""
+        conn = make_db()
+        output = capture_output(lambda: scraper.refresh_post_comments(conn, "testpub"))
+        self.assertIn("No posts loaded", output)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #33

## Problem
Sync on a pub tab was re-fetching comments for every loaded post — 70+ API calls, slow even when nothing changed.

## Fix
Fetch the full post list once (a few paginated calls) to get fresh comment counts, compare against stored values, only re-fetch comments for posts where the count changed. If nothing changed, sync completes almost instantly.

Log output now clearly shows:
- `"Post title": N new comment(s) from others` — actionable
- `"Post title": count changed (your own reply or edit) — nothing new to respond to` — not actionable

## Tests
5 unit tests with mocked API calls:
- No changes → "All up to date"
- New comment from another user
- Count change from own reply
- Multiple posts mixed
- No posts loaded

## Test plan
- [x] `python check.py` — all 9 checks pass
- [x] `python test_smart_sync.py` — all 5 tests pass
- [x] Live test: sync detected 1 changed post, correctly identified it as own reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)