### PR TITLE
Add in-repo app skill (launch + customize paths)

### DIFF
--- a/.claude/skills/substack-replies/SKILL.md
+++ b/.claude/skills/substack-replies/SKILL.md
@@ -26,7 +26,7 @@ Then follow the appropriate path below.
 ## PATH 1: Launch the app
 
 ```bash
-flask run --port 5001
+python app.py
 ```
 
 Then open http://localhost:5001. Walk them through what they're looking at if needed:
@@ -48,7 +48,7 @@ Ask them to describe what they want to change in plain language. Then:
 1. Figure out which file(s) are involved
 2. Explain what you're going to do before doing it
 3. Make the change
-4. Tell them to refresh the app (or restart `flask run`) to see the result
+4. Tell them to refresh the app (or restart `python app.py`) to see the result
 
 Key files:
 

--- a/.claude/skills/substack-replies/SKILL.md
+++ b/.claude/skills/substack-replies/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: substack-replies
+description: Use or customize the substack-replies app — a local dashboard for tracking and responding to Substack comments and replies
+disable-model-invocation: true
+---
+
+You are helping a Substack writer with the substack-replies app — a personal tool that pulls in all your Substack activity and shows it in a local dashboard so you can see what needs a response.
+
+Start by asking what they need:
+
+---
+
+Hi! I can help you with a couple of things:
+
+1. **Launch the app** — start it up and get oriented
+2. **Make a change** — customize something about how the app works
+
+Which one do you need?
+
+---
+
+Then follow the appropriate path below.
+
+---
+
+## PATH 1: Launch the app
+
+```bash
+flask run --port 5001
+```
+
+Then open http://localhost:5001. Walk them through what they're looking at if needed:
+
+- **Replies tab** — replies to your notes and comments that need a response
+- **Publication tabs** — comments on your own posts, organized by post
+- **Sync** — fetches new activity from Substack; run this periodically to stay current
+- **Load posts** (on pub tabs) — pulls in posts you haven't loaded yet
+- **Search bar** — filter by name, keyword, or phrase across all tabs simultaneously
+- **Liked toggle** — when on, liked replies move to a collapsed section instead of staying in the queue; default is on
+- **Responded / Archived** — collapsed sections at the bottom of each tab for things already handled
+
+---
+
+## PATH 2: Make a change
+
+Ask them to describe what they want to change in plain language. Then:
+
+1. Figure out which file(s) are involved
+2. Explain what you're going to do before doing it
+3. Make the change
+4. Tell them to refresh the app (or restart `flask run`) to see the result
+
+Key files:
+
+| File | Purpose |
+|------|---------|
+| `dashboard.py` | HTML rendering — layout, tabs, stats, search, toggle |
+| `scraper.py` | All sync / recheck / backfill logic, rate limiting |
+| `app.py` | Flask routes and SSE streaming |
+| `insights.py` | Insights page rendering |
+| `check.py` | Pre-commit integrity check — run before committing |
+
+Remind them at the start:
+
+---
+
+You don't need to know how to code for this — just describe what you want and I'll handle the technical side. We'll go step by step and I'll explain what I'm doing as we go.
+
+What would you like to change?
+
+---

--- a/README.md
+++ b/README.md
@@ -1,116 +1,68 @@
 # substack-replies
 
-A personal tool that scrapes your Substack replies and surfaces them in a local HTML dashboard so you can track which ones need a response.
+A personal tool for Substack writers who want one place to see what still needs a response — across notes, comments, and your own posts.
 
-Built for writers who publish on multiple Substack publications and want a single inbox view across all of them.
+This is not a managed service. It runs locally on your computer, stores your data in a local database, and talks to Substack directly using your own session. Nothing is hosted anywhere.
 
-> **Note on the API:** This tool uses Substack's internal API, which is unofficial and undocumented. It works as of the time of writing but could break if Substack changes their API. No data is sent anywhere — everything stays on your machine.
-
----
-
-## How it works
-
-1. Authenticates with Substack using your session cookie
-2. Fetches your activity feed (note replies, comment replies) and all comments on your own posts
-3. Stores everything in a local SQLite database (`replies.db`)
-4. Generates a self-contained HTML dashboard you open in your browser
+> **Note:** This uses Substack's internal API, which is unofficial, undocumented, and intended for personal use only. It works as of writing but could break if Substack changes things. The API is rate-limited — if you hit the limit, the app will stop and ask you to try again in a few minutes.
 
 ---
 
-## Setup
+## What you get
 
-**Recommended: use Claude Code to walk you through setup.** Once you've cloned the repo and set your session cookie, Claude can look up your account details and configure everything automatically. See step 3.
+**Replies tab** — replies to your Substack Notes, and replies to comments you've left on other people's posts and Notes. Shows what still needs a response. Use **Sync** to pull in new activity. You can set how many new replies to fetch at a time — the app rechecks your existing unresponded items first, then pulls in the most recent new replies up to your limit, then fills in older history if there's still room.
 
-### 1. Clone the repo
+**Publication tabs** — one tab per publication you own. Shows comments on your own posts. Use **Load posts** to pull in posts and their comments for the first time; use **Sync** to check for new activity — only posts where the comment count changed are re-fetched.
 
-```bash
-git clone https://github.com/alyssafuward/substack-replies.git
-cd substack-replies
-pip install -r requirements.txt
-```
+**Search** — filter by name, keyword, or phrase across all tabs simultaneously. Match counts appear in each tab label.
 
-### 2. Set your session cookie
+**Liked toggle** — if you ❤️ a reply on Substack, the app can treat that as "seen and acknowledged" and move it to a collapsed section on both the Replies and Publications tabs. Use the toggle below the search bar to turn this off — liked items will stay in the main queue until you respond or archive them.
 
-You need your `substack.sid` session cookie to authenticate API requests.
+**Archive** — dismiss a reply without responding to it. Useful for spam, drive-bys, or things you've read but don't want cluttering your queue. Available on the Replies tab only; Publications comments can't be archived yet.
 
-**To get it:**
-1. Open [substack.com](https://substack.com) logged in
-2. Open DevTools → **Application** tab → **Cookies** → `https://substack.com`
-3. Find the cookie named `substack.sid` and copy its value
+**Co-authored & guest posts** — replies from posts you've written for other publications show up in a separate collapsed section in the Replies tab, since they need a different kind of attention.
 
-**To store it:**
-```bash
-echo 'export SUBSTACK_SID="paste-your-value-here"' >> ~/.zshrc
-source ~/.zshrc
-```
+**Responded** — once you've replied to something, it moves to a collapsed Responded section so you can focus on what's still open.
 
-> **Security note:** The cookie is a live session credential — anyone who has it can act as you on Substack. It's stored in `~/.zshrc` on disk, readable by anything running as your user. It is never written to this repo or committed to git. If you think it's been exposed, log out of Substack to invalidate it and repeat the steps above with the new value. **Never paste the cookie value into chat** (including to Claude) — conversation content is sent to Anthropic's servers.
-
-### 3. Create your config file
-
-Copy `config.example.py` to `config.py`:
-
-```bash
-cp config.example.py config.py
-```
-
-`config.py` needs three values: your numeric user ID, your handle, and a dict of your publication subdomains and their IDs.
-
-**The easiest way to fill this in:** open Claude Code in this directory and say *"help me set up my config."* Claude can look up your account details automatically using your session cookie — no manual digging required.
-
-**To find the values yourself** (if not using Claude):
-1. Open [substack.com](https://substack.com) and log in
-2. Open DevTools → **Network** tab → reload the page
-3. Look for a request to `/api/v1/subscriber` — the response JSON contains your `user_id`
-4. For publication IDs, look for requests to `/api/v1/posts` — the publication `id` is in the response
-
-> **Security note:** `config.py` is gitignored and never committed. It contains your user ID and publication IDs — these are public Substack identifiers, but there's no reason to expose them in a public repo.
+**Your data** — everything lives in a local SQLite database. No cloud sync, no sharing. Data persists across page refreshes.
 
 ---
 
-## Usage
+## Requirements
 
-```bash
-# Fetch latest replies and comments (run this periodically)
-python scraper.py sync
+**The one thing you need to install yourself:**
 
-# Generate the dashboard and open it in your browser
-python dashboard.py
-```
+- **Claude Code** — this is how you'll interact with the app, run setup, and customize things later. [Download here.](https://claude.ai/code) Claude Code runs inside Terminal on your Mac.
 
-The dashboard shows:
-- Replies to your notes and comments that haven't been addressed yet
-- Comments on your own posts that are waiting for a reply
-- A "Show liked comments" toggle for items you've already engaged with
-- A "Done" section to track what you've handled this session
+**Everything else, Claude will help you set up:**
+
+- **Python 3** — to run the app
+- **GitHub account** — only needed if you want to customize the code and save your changes
+- **The code itself** — Claude will help you get a copy onto your machine
 
 ---
 
-## Files
+## Getting started
 
-```
-substack-replies/
-├── scraper.py          # fetches data from Substack API, stores in replies.db
-├── dashboard.py        # generates the HTML dashboard from replies.db
-├── config.example.py   # template — copy to config.py and fill in your values
-├── config.py           # your personal config (gitignored, never committed)
-├── replies.db          # local SQLite database (gitignored, never committed)
-├── dashboard.html      # generated output (gitignored, regenerated each run)
-├── check.py            # sanity checks — run after code changes to verify nothing is broken
-├── requirements.txt    # Python dependencies (just: requests)
-└── dev/
-    └── explore.py      # API exploration reference — used to reverse-engineer
-                        # the Substack API during development, not needed for normal use
-```
+**[Download the setup skill](https://raw.githubusercontent.com/alyssafuward/substack-replies/main/setup-skill/SKILL.md)** — right-click and Save As, or click Raw and use your browser's save option. Drop it in your Downloads folder. Then open Claude Code and say:
+
+> "Install the setup skill from my Downloads folder"
+
+Claude will walk you through everything: installing Python if needed, getting a copy of the code, setting up a GitHub account if you want one, getting your Substack credentials, configuring the app, and verifying it all works before you run it for the first time.
+
+**A note on Terminal.** Claude Code runs inside Terminal. If you haven't used it before — on a Mac, press `Cmd+Space`, type "Terminal", and hit enter. One thing that trips people up: Terminal is keyboard-only. You can't click to reposition your cursor inside a command the way you would in a text editor. Use the arrow keys to move around and edit. Claude will give you exact commands to run, so mostly you'll just be pasting (`Cmd+V`) and hitting enter.
 
 ---
 
-## Security summary
+## Security
 
-| What | Where | Risk |
-|------|-------|------|
-| Session cookie (`SUBSTACK_SID`) | `~/.zshrc` | Live credential. Rotate by logging out of Substack if exposed. |
-| User config (`config.py`) | Local only, gitignored | Contains public Substack IDs. Not sensitive, but kept off the repo. |
-| Reply data (`replies.db`) | Local only, gitignored | Contains your readers' names and comment text. Never committed. |
-| Generated dashboard (`dashboard.html`) | Local only, gitignored | Contains reply content. Never committed. |
-| Substack API | Unofficial, undocumented | Could break without notice. No write operations — read-only. |
+To fetch your data, the app uses your Substack session cookie — the same credential your browser uses when you're logged in. Claude will help you find it, copy it, and store it safely on your machine.
+
+A few things worth knowing:
+
+- The session cookie is a live credential. If you think it's been exposed, log out of Substack to invalidate it and run setup again with a fresh one.
+- **Never paste your session cookie into chat** — including to Claude. Conversation content is sent to Anthropic's servers.
+
+---
+
+Questions? Find me on Substack: [alyssafuward.substack.com](https://alyssafuward.substack.com)

--- a/dashboard.py
+++ b/dashboard.py
@@ -894,15 +894,19 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
     <button class="how-it-works-toggle" onclick="toggleHowItWorks(this)">How it works ▾</button>
     <div class="how-it-works" id="how-it-works">
       <h3>Replies tab</h3>
-      Shows replies to your notes and comments across Substack. Sync to pull in new activity. Items that need a response appear in the main queue.
+      Replies to your Substack Notes, and replies to comments you've left on other people's posts and Notes. Shows what still needs a response. Use <strong>Sync</strong> to pull in new activity. You can set how many new replies to fetch at a time — the app rechecks your existing unresponded items first, then pulls in the most recent new replies up to your limit, then fills in older history if there's still room.
       <h3>Publication tabs</h3>
-      Shows comments on your own posts that haven't been answered. Click <strong>Load posts</strong> to fetch posts (newest first). Click <strong>Sync</strong> to check already-loaded posts for new comments — only posts where the comment count changed are re-fetched.
-      <h3>Responded</h3>
-      Once you've replied to something, it moves to the collapsed Responded section so you can focus on what's still open.
-      <h3>Liked</h3>
-      Liking a reply on Substack marks it as acknowledged and moves it to a collapsed section on both the Replies and Publications tabs. Use the toggle below the search bar to turn this off — liked items will stay in the main queue until you respond or archive them. Note: archive is available on the Replies tab only; Publications comments can't be archived yet.
+      One tab per publication you own. Shows comments on your own posts. Use <strong>Load posts</strong> to pull in posts and their comments for the first time; use <strong>Sync</strong> to check for new activity — only posts where the comment count changed are re-fetched.
       <h3>Search</h3>
-      Search by name, keyword, or phrase — filters across all tabs simultaneously. Match counts appear in each tab label.
+      Filter by name, keyword, or phrase across all tabs simultaneously. Match counts appear in each tab label.
+      <h3>Liked toggle</h3>
+      If you ❤️ a reply on Substack, the app can treat that as "seen and acknowledged" and move it to a collapsed section on both tabs. Use the toggle below the search bar to turn this off — liked items will stay in the main queue until you respond or archive them.
+      <h3>Archive</h3>
+      Dismiss a reply without responding to it. Useful for spam, drive-bys, or things you've read but don't want cluttering your queue. Available on the Replies tab only; Publications comments can't be archived yet.
+      <h3>Co-authored &amp; guest posts</h3>
+      Replies from posts you've written for other publications show up in a separate collapsed section in the Replies tab, since they need a different kind of attention.
+      <h3>Responded</h3>
+      Once you've replied to something, it moves to a collapsed Responded section so you can focus on what's still open.
       <h3>Your data</h3>
       Everything lives in a local SQLite database — no cloud sync, no sharing. Data persists across page refreshes.
     </div>


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/substack-replies/SKILL.md` to the repo — covers launching the app and making changes
- The global `~/.claude/skills/substack-replies/SKILL.md` has been updated to be setup-only (first-time install), with a new Step 10 that asks users if they want to keep or remove it once setup is done
- The in-repo skill auto-loads when Claude Code is opened from the project directory; the setup skill becomes disposable

Closes #45

## Test plan
- [ ] Open Claude Code in the `substack-replies` directory and confirm the skill loads
- [ ] Verify the skill covers launch and make-a-change paths
- [ ] Check that the global setup skill's Step 10 points to the in-repo skill correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)