### PR TITLE
Fix sync stuck state, SQLite locking, and recheck accuracy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@
 ## How to run
 
 ```
-flask run --port 5001
+python app.py
 ```
 
 ## Key files

--- a/app.py
+++ b/app.py
@@ -118,10 +118,7 @@ def _stream(cmd):
         yield "data: __error__\n\n"
         return
 
-    if not started:
-        yield "data: __error__\n\n"
-        return
-
+    # Whether we started a new sync or attached to an existing one, tail the log
     yield from _tail_log(log_path)
 
 

--- a/app.py
+++ b/app.py
@@ -169,7 +169,7 @@ def archive():
     comment_id = request.json.get("comment_id")
     if not comment_id:
         return jsonify({"error": "missing comment_id"}), 400
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(DB_PATH, timeout=30) as conn:
         conn.execute(
             "UPDATE activity_items SET is_archived = 1 WHERE comment_id = ?",
             (comment_id,)
@@ -182,7 +182,7 @@ def unarchive():
     comment_id = request.json.get("comment_id")
     if not comment_id:
         return jsonify({"error": "missing comment_id"}), 400
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(DB_PATH, timeout=30) as conn:
         conn.execute(
             "UPDATE activity_items SET is_archived = 0 WHERE comment_id = ?",
             (comment_id,)
@@ -196,7 +196,7 @@ def insights():
         from flask import redirect
         return redirect("/")
     query = request.args.get("q", "").strip()
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(DB_PATH, timeout=30) as conn:
         data = load_insights(conn)
         search_results = search_commenter(conn, query) if query else None
     html = render_insights_html(data, query=query or None, search_results=search_results)
@@ -213,7 +213,7 @@ def index():
     active_tab = request.args.get("tab", "replies")
     liked_ack = request.args.get("liked_ack", "1") != "0"
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(DB_PATH, timeout=30) as conn:
         items = load_data(conn)
         stats = load_stats(conn)
         all_posts_data = {pub: load_post_comments_data(conn, pub) for pub in all_pubs}

--- a/dashboard.py
+++ b/dashboard.py
@@ -913,8 +913,9 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
     {f'<div class="gap-warning">⚠️ {stats["gap_warning"]}</div>' if stats.get("gap_warning") else ""}
   </div>
 
-  <div id="sync-busy-banner" style="display:none; max-width:720px; margin:0 auto 16px; background:#fff3cd; border:1px solid #ffc107; border-radius:8px; padding:10px 16px; font-size:0.88rem; color:#856404;">
-    A sync is already in progress. Please wait for it to finish before starting another.
+  <div id="sync-busy-banner" style="display:none; max-width:720px; margin:0 auto 16px; background:#fff3cd; border:1px solid #ffc107; border-radius:8px; padding:10px 16px; font-size:0.88rem; color:#856404; display:none; align-items:center; justify-content:space-between; gap:12px;">
+    <span>A sync is already in progress.</span>
+    <button onclick="fetch('/sync/stop',{{method:'POST'}}).then(()=>{{document.getElementById('sync-busy-banner').style.display='none';}})" style="background:#856404; color:#fff3cd; border:none; border-radius:4px; padding:4px 12px; font-size:0.82rem; cursor:pointer; white-space:nowrap;">Stop sync</button>
   </div>
 
   <div style="max-width:720px; margin:0 auto 10px;">
@@ -1534,7 +1535,7 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
       .then(r => r.json())
       .then(data => {{
         if (data.running) {{
-          document.getElementById('sync-busy-banner').style.display = '';
+          document.getElementById('sync-busy-banner').style.display = 'flex';
         }}
       }})
       .catch(() => {{}});

--- a/scraper.py
+++ b/scraper.py
@@ -266,7 +266,7 @@ def recheck_unresponded(conn):
         WHERE a.is_responded = 0
           AND a.type = 'comment_reply'
           AND a.comment_id IS NOT NULL
-          AND a.is_archived = 0
+          AND (a.is_archived IS NULL OR a.is_archived = 0)
           AND json_extract(c.raw_json, '$.reaction') IS NULL  -- liked = acknowledged, skip recheck
           AND NOT EXISTS (
               SELECT 1 FROM comments r
@@ -281,7 +281,7 @@ def recheck_unresponded(conn):
         return 0
 
     # Group items by (subdomain, post_id) to fetch each post's comments only once
-    groups = {}  # (subdomain, post_id) -> [(item_id, comment_id), ...]
+    groups = {}  # (subdomain, post_id) -> [(item_id, comment_id, is_guest), ...]
     skip_count = 0
 
     for item_id, comment_id, post_id in rows:
@@ -302,12 +302,14 @@ def recheck_unresponded(conn):
             continue
 
         subdomain = host.replace(".substack.com", "")
+        is_guest = not any(f"{sub}.substack.com" in post_url for sub in OWN_PUBS)
         key = (subdomain, post_id)
-        groups.setdefault(key, []).append((item_id, comment_id))
+        groups.setdefault(key, []).append((item_id, comment_id, is_guest))
 
     num_groups = len(groups)
     print(f"{ts()} Rechecking {len(rows)} comment replies across {num_groups} posts...")
     still_unresponded = skip_count
+    still_unresponded_guest = 0
     newly_responded = 0
 
     for gi, ((subdomain, post_id), items) in enumerate(groups.items(), 1):
@@ -315,7 +317,7 @@ def recheck_unresponded(conn):
             comments = fetch_post_comments(subdomain, post_id)
             print(f"{ts()}   [{gi}/{num_groups}] post {post_id} — {len(items)} comment(s)")
 
-            for item_id, comment_id in items:
+            for item_id, comment_id, is_guest in items:
                 # Refresh stored comment with fresh data (includes current reaction)
                 fresh = _find_comment(comments, comment_id)
                 if fresh:
@@ -332,7 +334,10 @@ def recheck_unresponded(conn):
                     newly_responded += 1
                     print(f"{ts()}     responded ✓")
                 else:
-                    still_unresponded += 1
+                    if is_guest:
+                        still_unresponded_guest += 1
+                    else:
+                        still_unresponded += 1
                     print(f"{ts()}     still unresponded")
 
         except Exception as e:
@@ -342,7 +347,8 @@ def recheck_unresponded(conn):
         time.sleep(1)
 
     conn.commit()
-    print(f"{ts()} Recheck done: {newly_responded} newly responded, {still_unresponded} still unresponded")
+    guest_note = f", {still_unresponded_guest} in guest/co-authored posts" if still_unresponded_guest else ""
+    print(f"{ts()} Recheck done: {newly_responded} newly responded, {still_unresponded} still unresponded{guest_note}")
     return still_unresponded
 
 # ── Sync: Activity Feed ───────────────────────────────────────────────────────

--- a/scraper.py
+++ b/scraper.py
@@ -125,6 +125,9 @@ def init_db(conn):
         );
     """)
 
+    # WAL mode: allows concurrent reads and writes between Flask and the scraper subprocess
+    conn.execute("PRAGMA journal_mode=WAL")
+
     # Migrate existing DB: add is_responded if it doesn't exist yet
     try:
         conn.execute("ALTER TABLE activity_items ADD COLUMN is_responded INTEGER DEFAULT 0")
@@ -1017,7 +1020,7 @@ def main():
         print("Usage: python scraper.py [sync] [report] [load-post --pub X] [sync-posts --pub X] [--as-of YYYY-MM-DD]")
         sys.exit(0)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(DB_PATH, timeout=30) as conn:
         init_db(conn)
 
         if "load-posts" in args:

--- a/scraper.py
+++ b/scraper.py
@@ -268,9 +268,13 @@ def recheck_unresponded(conn):
           AND a.comment_id IS NOT NULL
           AND a.is_archived = 0
           AND json_extract(c.raw_json, '$.reaction') IS NULL  -- liked = acknowledged, skip recheck
+          AND NOT EXISTS (
+              SELECT 1 FROM comments r
+              WHERE r.user_id = ? AND r.ancestor_path LIKE '%' || a.comment_id || '%' AND r.id > a.comment_id
+          )
         ORDER BY a.updated_at DESC
         LIMIT ?
-    """, (UNRESPONDED_TARGET * 2,)).fetchall()
+    """, (USER_ID, UNRESPONDED_TARGET * 2,)).fetchall()
 
     if not rows:
         print(f"{ts()} Recheck: nothing to check.")

--- a/scraper.py
+++ b/scraper.py
@@ -262,11 +262,12 @@ def recheck_unresponded(conn):
     rows = conn.execute("""
         SELECT a.id, a.comment_id, a.target_post_id
         FROM activity_items a
-        LEFT JOIN comments c ON c.id = a.comment_id
+        JOIN comments c ON c.id = a.comment_id
         WHERE a.is_responded = 0
           AND a.type = 'comment_reply'
           AND a.comment_id IS NOT NULL
-          AND (c.raw_json IS NULL OR json_extract(c.raw_json, '$.reaction') IS NULL)  -- liked = acknowledged, skip recheck
+          AND a.is_archived = 0
+          AND json_extract(c.raw_json, '$.reaction') IS NULL  -- liked = acknowledged, skip recheck
         ORDER BY a.updated_at DESC
         LIMIT ?
     """, (UNRESPONDED_TARGET * 2,)).fetchall()


### PR DESCRIPTION
## Summary
- **Sync reconnect**: `_stream()` now tails the existing log when a sync is already running instead of returning `__error__`. Page refresh + clicking Sync reconnects to the running process.
- **Busy banner**: Added a Stop button to the "sync already in progress" banner so there's always an escape on page refresh.
- **SQLite locking**: Enable WAL journal mode so Flask and the scraper subprocess can read/write concurrently. Bumps connection timeout to 30s.
- **Recheck accuracy**: Fixed recheck query to use INNER JOIN (skip orphaned items), exclude archived items, and exclude items where a reply already exists in the DB — so recheck count matches what the UI shows.
- **Guest post split**: Recheck now tracks guest/co-authored post items separately and reports them as a parenthetical in the log, matching the UI's "All caught up!" state.
- **`python app.py`**: Updated CLAUDE.md to use `python app.py` instead of `flask run`.

Closes #47

## Test plan
- [ ] Start sync, refresh mid-sync — clicking Sync reconnects and shows progress
- [ ] Start sync, refresh — yellow banner shows with Stop button
- [ ] Run sync — no "database is locked" warnings during recheck
- [ ] When UI shows "All caught up!", recheck log shows 0 still unresponded (guest items listed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)