### PR TITLE
Add GitHub Pages how-it-works page

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,6 +190,12 @@ def unarchive():
     return jsonify({"ok": True})
 
 
+@app.route("/how-it-works")
+def how_it_works():
+    p = Path(__file__).parent / "docs" / "index.html"
+    return Response(p.read_text(), mimetype="text/html")
+
+
 @app.route("/insights")
 def insights():
     if not DB_PATH.exists():

--- a/dashboard.py
+++ b/dashboard.py
@@ -883,7 +883,7 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
   <div class="header">
     <h1>Substack Replies</h1>
     <div class="tagline">Stay on top of replies across your Substack notes, comments, and posts.</div>
-    <a class="how-it-works-link" href="https://alyssafuward.github.io/substack-replies" target="_blank" rel="noopener">How it works ↗</a>
+    <a class="how-it-works-link" href="/how-it-works" target="_blank" rel="noopener">How it works ↗</a>
     <div class="stats">
       <div class="stat"><strong>{stats['activity_items']}</strong>replies tracked</div>
       <!-- insights link hidden: <a href="/insights" target="_blank" class="stat stat-link"><strong>Insights</strong>Dashboard →</a> -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -847,19 +847,11 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
     }}
     .toggle-btn:hover {{ color: #666; }}
     .intro {{ max-width: 720px; margin: 0 auto 16px; font-size: 0.88rem; color: #666; line-height: 1.5; }}
-    .how-it-works-toggle {{
-      background: none; border: none; cursor: pointer;
-      font-size: 0.8rem; color: #bbb; padding: 0; margin-top: 6px;
-      display: block; text-decoration: underline; text-underline-offset: 2px;
+    .how-it-works-link {{
+      font-size: 0.8rem; color: #bbb; margin-top: 6px;
+      display: block; text-underline-offset: 2px;
     }}
-    .how-it-works-toggle:hover {{ color: #888; }}
-    .how-it-works {{
-      display: none; margin-top: 12px; padding: 14px 16px;
-      background: white; border-radius: 8px; border: 1px solid #e5e5e5;
-      font-size: 0.84rem; color: #555; line-height: 1.6;
-    }}
-    .how-it-works h3 {{ font-size: 0.78rem; font-weight: 700; color: #aaa; text-transform: uppercase; letter-spacing: 0.05em; margin: 12px 0 4px; }}
-    .how-it-works h3:first-child {{ margin-top: 0; }}
+    .how-it-works-link:hover {{ color: #888; }}
     .liked-section {{ display: none; margin-top: 10px; }}
     .liked-section .card {{ opacity: 0.55; background: #fafafa; }}
     .liked-section .card:hover {{ opacity: 0.8; }}
@@ -891,21 +883,7 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
   <div class="header">
     <h1>Substack Replies</h1>
     <div class="tagline">Stay on top of replies across your Substack notes, comments, and posts.</div>
-    <button class="how-it-works-toggle" onclick="toggleHowItWorks(this)">How it works ▾</button>
-    <div class="how-it-works" id="how-it-works">
-      <h3>Replies tab</h3>
-      Shows replies to your notes and comments across Substack. Sync to pull in new activity. Items that need a response appear in the main queue.
-      <h3>Publication tabs</h3>
-      Shows comments on your own posts that haven't been answered. Click <strong>Load posts</strong> to fetch posts (newest first). Click <strong>Sync</strong> to check already-loaded posts for new comments — only posts where the comment count changed are re-fetched.
-      <h3>Responded</h3>
-      Once you've replied to something, it moves to the collapsed Responded section so you can focus on what's still open.
-      <h3>Liked</h3>
-      Liking a reply on Substack marks it as acknowledged and moves it to a collapsed section on both the Replies and Publications tabs. Use the toggle below the search bar to turn this off — liked items will stay in the main queue until you respond or archive them. Note: archive is available on the Replies tab only; Publications comments can't be archived yet.
-      <h3>Search</h3>
-      Search by name, keyword, or phrase — filters across all tabs simultaneously. Match counts appear in each tab label.
-      <h3>Your data</h3>
-      Everything lives in a local SQLite database — no cloud sync, no sharing. Data persists across page refreshes.
-    </div>
+    <a class="how-it-works-link" href="https://alyssafuward.github.io/substack-replies" target="_blank" rel="noopener">How it works ↗</a>
     <div class="stats">
       <div class="stat"><strong>{stats['activity_items']}</strong>replies tracked</div>
       <!-- insights link hidden: <a href="/insights" target="_blank" class="stat stat-link"><strong>Insights</strong>Dashboard →</a> -->
@@ -1120,13 +1098,6 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
       const open = older.style.display === 'block';
       older.style.display = open ? 'none' : 'block';
       btn.textContent = open ? btn.textContent.replace('▲', '▶') : btn.textContent.replace('▶', '▲');
-    }}
-
-    function toggleHowItWorks(btn) {{
-      const el = document.getElementById('how-it-works');
-      const open = el.style.display === 'block';
-      el.style.display = open ? 'none' : 'block';
-      btn.textContent = open ? 'How it works ▾' : 'How it works ▴';
     }}
 
     function toggleGuest(btn) {{

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,19 @@
       margin: 36px 0;
     }
 
+    .spinner {
+      display: inline-block;
+      width: 11px;
+      height: 11px;
+      border: 2px solid #ccc;
+      border-top-color: #888;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      vertical-align: middle;
+      margin-left: 6px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
     .bottom-nav {
       display: flex;
       justify-content: space-between;
@@ -212,17 +225,23 @@
     function goBack(el) {
       var h = window.location.hostname;
       if (h === 'localhost' || h === '127.0.0.1') {
-        // served by the app — just go back
         window.location.href = '/';
       } else if (h === '') {
         // opened as a file — check if the app is running
-        fetch('http://localhost:5001', { mode: 'no-cors' })
-          .then(function() { window.location.href = 'http://localhost:5001'; })
+        el.innerHTML = '← Back to app <span class="spinner"></span>';
+        var controller = new AbortController();
+        var timer = setTimeout(function() { controller.abort(); }, 1500);
+        fetch('http://localhost:5001', { mode: 'no-cors', signal: controller.signal })
+          .then(function() {
+            clearTimeout(timer);
+            window.location.href = 'http://localhost:5001';
+          })
           .catch(function() {
+            clearTimeout(timer);
+            el.textContent = '← Back to app';
             showHint(el, 'The app isn\'t running. To start it: open Terminal, navigate to the substack-replies folder, and run <code>python app.py</code>. Then open <a href="http://localhost:5001">http://localhost:5001</a>.');
           });
       } else {
-        // GitHub Pages
         showHint(el, 'The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.');
       }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,7 +193,7 @@
 
     <div class="bottom-nav">
       <a class="back" id="back-bottom" onclick="goBack(this)">← Back to app</a>
-      <div class="new-here">New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started">Get started →</a></div>
+      <div class="new-here">New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started" target="_blank" rel="noopener">Get started →</a></div>
     </div>
     <div class="app-hint" id="hint-bottom" style="margin-top:8px;">
       The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Substack Replies — How it works</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f5f4f0;
+      color: #1a1a1a;
+      padding: 40px 20px 80px;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 680px;
+      margin: 0 auto;
+    }
+
+    .back {
+      display: inline-block;
+      font-size: 0.82rem;
+      color: #aaa;
+      text-decoration: none;
+      margin-bottom: 32px;
+    }
+    .back:hover { color: #666; }
+
+    h1 {
+      font-size: 1.7rem;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+
+    .tagline {
+      font-size: 0.95rem;
+      color: #666;
+      margin-bottom: 32px;
+    }
+
+    .note {
+      background: white;
+      border: 1px solid #e5e5e5;
+      border-radius: 8px;
+      padding: 12px 16px;
+      font-size: 0.84rem;
+      color: #777;
+      margin-bottom: 36px;
+      line-height: 1.5;
+    }
+
+    .section {
+      background: white;
+      border: 1px solid #e5e5e5;
+      border-radius: 10px;
+      padding: 20px 22px;
+      margin-bottom: 12px;
+    }
+
+    .section-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      color: #ff3300;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      margin-bottom: 6px;
+    }
+
+    .section-title {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+
+    .section p {
+      font-size: 0.88rem;
+      color: #555;
+      line-height: 1.65;
+    }
+
+    .section p + p {
+      margin-top: 8px;
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid #e5e5e5;
+      margin: 36px 0;
+    }
+
+    .cta {
+      text-align: center;
+      padding: 8px 0;
+    }
+
+    .cta p {
+      font-size: 0.88rem;
+      color: #666;
+      margin-bottom: 14px;
+    }
+
+    .cta a {
+      display: inline-block;
+      background: #ff3300;
+      color: white;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.9rem;
+      padding: 10px 24px;
+      border-radius: 7px;
+    }
+
+    .cta a:hover { background: #e02d00; }
+
+    .footer {
+      margin-top: 48px;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #bbb;
+    }
+
+    .footer a { color: #bbb; }
+    .footer a:hover { color: #888; }
+  </style>
+</head>
+<body>
+  <div class="container">
+
+    <a class="back" href="https://github.com/alyssafuward/substack-replies">← Back to repo</a>
+
+    <h1>Substack Replies</h1>
+    <p class="tagline">A personal tool for Substack writers who want one place to see what still needs a response — across notes, comments, and your own posts.</p>
+
+    <div class="note">
+      This is not a managed service. It runs locally on your computer, stores your data in a local database, and talks to Substack directly using your own session. Nothing is hosted anywhere.
+    </div>
+
+    <div class="section">
+      <div class="section-label">Replies tab</div>
+      <p>Replies to your Substack Notes, and replies to comments you've left on other people's posts and Notes. Shows what still needs a response.</p>
+      <p>Use <strong>Sync</strong> to pull in new activity. You can set how many new replies to fetch at a time — the app rechecks your existing unresponded items first, then pulls in the most recent new replies up to your limit, then fills in older history if there's still room.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Publication tabs</div>
+      <p>One tab per publication you own. Shows comments on your own posts. Use <strong>Load posts</strong> to pull in posts and their comments for the first time; use <strong>Sync</strong> to check for new activity — only posts where the comment count changed are re-fetched.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Search</div>
+      <p>Filter by name, keyword, or phrase across all tabs simultaneously. Match counts appear in each tab label.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Liked toggle</div>
+      <p>If you ❤️ a reply on Substack, the app can treat that as "seen and acknowledged" and move it to a collapsed section on both the Replies and Publications tabs. Use the toggle below the search bar to turn this off — liked items will stay in the main queue until you respond or archive them.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Archive</div>
+      <p>Dismiss a reply without responding to it. Useful for spam, drive-bys, or things you've read but don't want cluttering your queue. Available on the Replies tab only; Publications comments can't be archived yet.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Co-authored &amp; guest posts</div>
+      <p>Replies from posts you've written for other publications show up in a separate collapsed section in the Replies tab, since they need a different kind of attention.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Responded</div>
+      <p>Once you've replied to something, it moves to a collapsed Responded section so you can focus on what's still open.</p>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Your data</div>
+      <p>Everything lives in a local SQLite database. No cloud sync, no sharing. Data persists across page refreshes.</p>
+    </div>
+
+    <hr>
+
+    <div class="cta">
+      <p>Ready to set it up?</p>
+      <a href="https://github.com/alyssafuward/substack-replies#getting-started">Get started →</a>
+    </div>
+
+    <div class="footer">
+      Built by <a href="https://alyssafuward.substack.com">Alyssa Fu Ward</a>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,9 +131,7 @@
   <div class="container">
 
     <a class="back" id="back-top" onclick="goBack(this)">← Back to app</a>
-    <div class="app-hint" id="hint-top">
-      The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.
-    </div>
+    <div class="app-hint" id="hint-top"></div>
 
     <br>
 
@@ -195,9 +193,7 @@
       <a class="back" id="back-bottom" onclick="goBack(this)">← Back to app</a>
       <div class="new-here">New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started" target="_blank" rel="noopener">Get started →</a></div>
     </div>
-    <div class="app-hint" id="hint-bottom" style="margin-top:8px;">
-      The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.
-    </div>
+    <div class="app-hint" id="hint-bottom" style="margin-top:8px;"></div>
 
     <div class="footer">
       Built by <a href="https://alyssafuward.substack.com">Alyssa Fu Ward</a>
@@ -206,12 +202,28 @@
   </div>
 
   <script>
+    function showHint(el, msg) {
+      var hintId = el.id === 'back-top' ? 'hint-top' : 'hint-bottom';
+      var hint = document.getElementById(hintId);
+      if (msg) hint.innerHTML = msg;
+      hint.style.display = 'block';
+    }
+
     function goBack(el) {
-      if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+      var h = window.location.hostname;
+      if (h === 'localhost' || h === '127.0.0.1') {
+        // served by the app — just go back
         window.location.href = '/';
+      } else if (h === '') {
+        // opened as a file — check if the app is running
+        fetch('http://localhost:5001', { mode: 'no-cors' })
+          .then(function() { window.location.href = 'http://localhost:5001'; })
+          .catch(function() {
+            showHint(el, 'The app isn\'t running. To start it: open Terminal, navigate to the substack-replies folder, and run <code>python app.py</code>. Then open <a href="http://localhost:5001">http://localhost:5001</a>.');
+          });
       } else {
-        var hintId = el.id === 'back-top' ? 'hint-top' : 'hint-bottom';
-        document.getElementById(hintId).style.display = 'block';
+        // GitHub Pages
+        showHint(el, 'The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.');
       }
     }
   </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,8 +26,20 @@
       color: #aaa;
       text-decoration: none;
       margin-bottom: 32px;
+      cursor: pointer;
     }
     .back:hover { color: #666; }
+
+    .app-hint {
+      display: none;
+      margin-top: 8px;
+      font-size: 0.82rem;
+      color: #666;
+      background: white;
+      border: 1px solid #e5e5e5;
+      border-radius: 6px;
+      padding: 8px 12px;
+    }
 
     h1 {
       font-size: 1.7rem;
@@ -38,7 +50,7 @@
     .tagline {
       font-size: 0.95rem;
       color: #666;
-      margin-bottom: 32px;
+      margin-bottom: 20px;
     }
 
     .note {
@@ -50,6 +62,10 @@
       color: #777;
       margin-bottom: 36px;
       line-height: 1.5;
+    }
+
+    .note + .note {
+      margin-top: -24px;
     }
 
     .section {
@@ -69,12 +85,6 @@
       margin-bottom: 6px;
     }
 
-    .section-title {
-      font-size: 1rem;
-      font-weight: 700;
-      margin-bottom: 8px;
-    }
-
     .section p {
       font-size: 0.88rem;
       color: #555;
@@ -91,29 +101,13 @@
       margin: 36px 0;
     }
 
-    .cta {
-      text-align: center;
-      padding: 8px 0;
+    .bottom-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
     }
-
-    .cta p {
-      font-size: 0.88rem;
-      color: #666;
-      margin-bottom: 14px;
-    }
-
-    .cta a {
-      display: inline-block;
-      background: #ff3300;
-      color: white;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.9rem;
-      padding: 10px 24px;
-      border-radius: 7px;
-    }
-
-    .cta a:hover { background: #e02d00; }
 
     .footer {
       margin-top: 48px;
@@ -124,18 +118,34 @@
 
     .footer a { color: #bbb; }
     .footer a:hover { color: #888; }
+
+    .new-here {
+      font-size: 0.82rem;
+      color: #aaa;
+    }
+    .new-here a { color: #aaa; }
+    .new-here a:hover { color: #666; }
   </style>
 </head>
 <body>
   <div class="container">
 
-    <a class="back" href="https://github.com/alyssafuward/substack-replies">← Back to repo</a>
+    <a class="back" id="back-top" onclick="goBack(this)">← Back to app</a>
+    <div class="app-hint" id="hint-top">
+      The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.
+    </div>
+
+    <br>
 
     <h1>Substack Replies</h1>
     <p class="tagline">A personal tool for Substack writers who want one place to see what still needs a response — across notes, comments, and your own posts.</p>
 
     <div class="note">
       This is not a managed service. It runs locally on your computer, stores your data in a local database, and talks to Substack directly using your own session. Nothing is hosted anywhere.
+    </div>
+
+    <div class="note">
+      <strong>Note on the API:</strong> This uses Substack's internal API, which is unofficial, undocumented, and intended for personal use only. It works as of writing but could break if Substack changes things. The API is rate-limited — if you hit the limit, the app will stop and ask you to try again in a few minutes.
     </div>
 
     <div class="section">
@@ -181,9 +191,12 @@
 
     <hr>
 
-    <div class="cta">
-      <p>Ready to set it up?</p>
-      <a href="https://github.com/alyssafuward/substack-replies#getting-started">Get started →</a>
+    <div class="bottom-nav">
+      <a class="back" id="back-bottom" onclick="goBack(this)">← Back to app</a>
+      <div class="new-here">New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started">Get started →</a></div>
+    </div>
+    <div class="app-hint" id="hint-bottom" style="margin-top:8px;">
+      The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.
     </div>
 
     <div class="footer">
@@ -191,5 +204,16 @@
     </div>
 
   </div>
+
+  <script>
+    function goBack(el) {
+      if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+        window.location.href = '/';
+      } else {
+        var hintId = el.id === 'back-top' ? 'hint-top' : 'hint-bottom';
+        document.getElementById(hintId).style.display = 'block';
+      }
+    }
+  </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,27 +20,6 @@
       margin: 0 auto;
     }
 
-    .back {
-      display: inline-block;
-      font-size: 0.82rem;
-      color: #aaa;
-      text-decoration: none;
-      margin-bottom: 32px;
-      cursor: pointer;
-    }
-    .back:hover { color: #666; }
-
-    .app-hint {
-      display: none;
-      margin-top: 8px;
-      font-size: 0.82rem;
-      color: #666;
-      background: white;
-      border: 1px solid #e5e5e5;
-      border-radius: 6px;
-      padding: 8px 12px;
-    }
-
     h1 {
       font-size: 1.7rem;
       font-weight: 700;
@@ -60,12 +39,12 @@
       padding: 12px 16px;
       font-size: 0.84rem;
       color: #777;
-      margin-bottom: 36px;
+      margin-bottom: 12px;
       line-height: 1.5;
     }
 
-    .note + .note {
-      margin-top: -24px;
+    .notes-group {
+      margin-bottom: 36px;
     }
 
     .section {
@@ -101,62 +80,32 @@
       margin: 36px 0;
     }
 
-    .spinner {
-      display: inline-block;
-      width: 11px;
-      height: 11px;
-      border: 2px solid #ccc;
-      border-top-color: #888;
-      border-radius: 50%;
-      animation: spin 0.6s linear infinite;
-      vertical-align: middle;
-      margin-left: 6px;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
-
-    .bottom-nav {
+    .footer {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
-    .footer {
-      margin-top: 48px;
-      text-align: center;
+      margin-top: 36px;
       font-size: 0.8rem;
       color: #bbb;
     }
 
     .footer a { color: #bbb; }
     .footer a:hover { color: #888; }
-
-    .new-here {
-      font-size: 0.82rem;
-      color: #aaa;
-    }
-    .new-here a { color: #aaa; }
-    .new-here a:hover { color: #666; }
   </style>
 </head>
 <body>
   <div class="container">
 
-    <a class="back" id="back-top" onclick="goBack(this)">← Back to app</a>
-    <div class="app-hint" id="hint-top"></div>
-
-    <br>
-
     <h1>Substack Replies</h1>
     <p class="tagline">A personal tool for Substack writers who want one place to see what still needs a response — across notes, comments, and your own posts.</p>
 
-    <div class="note">
-      This is not a managed service. It runs locally on your computer, stores your data in a local database, and talks to Substack directly using your own session. Nothing is hosted anywhere.
-    </div>
-
-    <div class="note">
-      <strong>Note on the API:</strong> This uses Substack's internal API, which is unofficial, undocumented, and intended for personal use only. It works as of writing but could break if Substack changes things. The API is rate-limited — if you hit the limit, the app will stop and ask you to try again in a few minutes.
+    <div class="notes-group">
+      <div class="note">
+        This is not a managed service. It runs locally on your computer, stores your data in a local database, and talks to Substack directly using your own session. Nothing is hosted anywhere.
+      </div>
+      <div class="note">
+        <strong>Note on the API:</strong> This uses Substack's internal API, which is unofficial, undocumented, and intended for personal use only. It works as of writing but could break if Substack changes things. The API is rate-limited — if you hit the limit, the app will stop and ask you to try again in a few minutes.
+      </div>
     </div>
 
     <div class="section">
@@ -200,51 +149,11 @@
       <p>Everything lives in a local SQLite database. No cloud sync, no sharing. Data persists across page refreshes.</p>
     </div>
 
-    <hr>
-
-    <div class="bottom-nav">
-      <a class="back" id="back-bottom" onclick="goBack(this)">← Back to app</a>
-      <div class="new-here">New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started" target="_blank" rel="noopener">Get started →</a></div>
-    </div>
-    <div class="app-hint" id="hint-bottom" style="margin-top:8px;"></div>
-
     <div class="footer">
-      Built by <a href="https://alyssafuward.substack.com">Alyssa Fu Ward</a>
+      <span>Built by <a href="https://alyssafuward.substack.com">Alyssa Fu Ward</a></span>
+      <span>New here? <a href="https://github.com/alyssafuward/substack-replies#getting-started" target="_blank" rel="noopener">Get started →</a></span>
     </div>
 
   </div>
-
-  <script>
-    function showHint(el, msg) {
-      var hintId = el.id === 'back-top' ? 'hint-top' : 'hint-bottom';
-      var hint = document.getElementById(hintId);
-      if (msg) hint.innerHTML = msg;
-      hint.style.display = 'block';
-    }
-
-    function goBack(el) {
-      var h = window.location.hostname;
-      if (h === 'localhost' || h === '127.0.0.1') {
-        window.location.href = '/';
-      } else if (h === '') {
-        // opened as a file — check if the app is running
-        el.innerHTML = '← Back to app <span class="spinner"></span>';
-        var controller = new AbortController();
-        var timer = setTimeout(function() { controller.abort(); }, 1500);
-        fetch('http://localhost:5001', { mode: 'no-cors', signal: controller.signal })
-          .then(function() {
-            clearTimeout(timer);
-            window.location.href = 'http://localhost:5001';
-          })
-          .catch(function() {
-            clearTimeout(timer);
-            el.textContent = '← Back to app';
-            showHint(el, 'The app isn\'t running. To start it: open Terminal, navigate to the substack-replies folder, and run <code>python app.py</code>. Then open <a href="http://localhost:5001">http://localhost:5001</a>.');
-          });
-      } else {
-        showHint(el, 'The app runs locally. Open <a href="http://localhost:5001">http://localhost:5001</a> in your browser.');
-      }
-    }
-  </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #49

## What
- `docs/index.html` — styled "How it works" page at `alyssafuward.github.io/substack-replies` (app style: cream bg, red accent labels, white cards)
- `dashboard.py` — replace inline expandable with a `How it works ↗` link that opens the GitHub Pages page in a new tab

## After merging
Enable GitHub Pages in repo Settings → Pages → Source: **Deploy from a branch** → Branch: `main`, folder: `/docs`.