### PR TITLE
Add URL-driven onboarding: SETUP.md + expanded CLAUDE.md setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,41 +17,118 @@ If it's missing or expired:
 
 ## First-time setup (new user, no config.py)
 
-If `config.py` doesn't exist, the user needs to set it up. Once `SUBSTACK_SID` is set, Claude can look up all the values automatically — no manual digging needed.
+If `config.py` doesn't exist, follow these steps in order.
 
-Ask the user for their Substack handle and any publication subdomains they own, then run:
+### 1. Check prerequisites
+
+```bash
+python3 --version
+git --version
+```
+
+If Python 3 isn't installed, tell the user to download it from python.org and come back. On Mac, if Git isn't installed, `git --version` may trigger a prompt to install Xcode Command Line Tools — warn them it's safe.
+
+### 2. Fork or clone?
+
+Ask the user:
+
+> Quick question before we download the app: do you think you might want to customize it — change how it looks, what it tracks, how things are organized? Or do you just want to try it out as-is?
+>
+> - **Just try it out** → simple download, no GitHub account needed.
+> - **I want to customize it** → we'll set up your own copy on GitHub. You'll need a free GitHub account.
+
+**If just trying it out (clone):**
+
+```bash
+mkdir -p ~/Projects
+cd ~/Projects
+git clone https://github.com/alyssafuward/substack-replies.git
+cd substack-replies
+pip install -r requirements.txt
+```
+
+**If they want to customize (fork + clone):**
+
+If they don't have a GitHub account, tell them to create one at github.com. Then:
+
+1. Tell them to go to https://github.com/alyssafuward/substack-replies and click **Fork** → **Create fork**
+2. Ask for their GitHub username, then:
+
+```bash
+mkdir -p ~/Projects
+cd ~/Projects
+git clone https://github.com/THEIR-USERNAME/substack-replies.git
+cd substack-replies
+pip install -r requirements.txt
+```
+
+### 3. Get the Substack session cookie
+
+The user does this themselves — **do not have them paste the cookie value into chat**. Conversation content is sent to Anthropic's servers and the cookie is a live credential.
+
+Tell the user:
+
+> This is the one part I can't do for you. A session cookie is how your browser proves to Substack that you're logged in — we need it so the app can fetch your data. Don't share it with anyone, including me. I'll give you a command to store it safely on your machine.
+
+Walk them through finding it:
+1. Open [substack.com](https://substack.com) logged in
+2. Open DevTools: `Cmd+Option+I` (Mac) or `F12` (Windows)
+3. Click **Application** tab → **Cookies** → `https://substack.com`
+4. Find `substack.sid` and copy its value
+
+Give them this command to run in Terminal (they replace the placeholder with their value):
+
+```bash
+echo 'export SUBSTACK_SID="paste-your-value-here"' >> ~/.zshrc && source ~/.zshrc
+```
+
+Verify it took:
+
+```bash
+echo $SUBSTACK_SID
+```
+
+If it prints nothing, troubleshoot — they may be on a different shell (`echo $SHELL`).
+
+### 4. Look up their account details
+
+Once `SUBSTACK_SID` is set, fetch their user ID and handle automatically:
 
 ```python
-import requests, os, json
+import requests, os
 from urllib.parse import unquote
-
 sid = os.environ.get("SUBSTACK_SID", "")
 headers = {
     "Cookie": f"substack.sid={unquote(sid)}",
     "Accept": "application/json",
     "User-Agent": "Mozilla/5.0",
 }
-
-# Get user ID
 resp = requests.get("https://substack.com/api/v1/subscriber", headers=headers)
 data = resp.json()
-user_id = data.get("id") or data.get("user_id")
-handle = data.get("handle", "")
-print(f"USER_ID: {user_id}")
-print(f"HANDLE: {handle}")
+print(f"USER_ID: {data.get('id') or data.get('user_id')}")
+print(f"HANDLE: {data.get('handle', '')}")
 ```
 
-Then for each publication subdomain the user provides, fetch its ID:
+### 5. Get publication IDs
+
+Ask for the subdomain(s) of their Substack publication(s) — the part before `.substack.com`. For each one:
 
 ```python
-subdomain = "their-subdomain"  # replace with actual
+import requests, os
+from urllib.parse import unquote
+subdomain = "REPLACE_WITH_SUBDOMAIN"
+sid = os.environ.get("SUBSTACK_SID", "")
+headers = {
+    "Cookie": f"substack.sid={unquote(sid)}",
+    "Accept": "application/json",
+    "User-Agent": "Mozilla/5.0",
+}
 resp = requests.get(f"https://{subdomain}.substack.com/api/v1/publication", headers=headers)
-pub_data = resp.json()
-pub_id = pub_data.get("id")
-print(f"{subdomain}: {pub_id}")
+data = resp.json()
+print(f"{subdomain}: {data.get('id')}")
 ```
 
-Use the results to create `config.py`:
+### 6. Create config.py
 
 ```python
 USER_ID = <user_id>
@@ -63,7 +140,26 @@ OWN_PUBS = {
 }
 ```
 
-Then run `python check.py` to verify everything is working.
+### 7. Verify and run
+
+```bash
+python check.py
+```
+
+If any checks fail, diagnose before continuing. Then start the app:
+
+```bash
+python app.py
+```
+
+Tell the user to open http://localhost:5001. Explain that this is local to their computer — it's not a website anyone else can see.
+
+### 8. Walk them through first use
+
+- **Replies tab** — replies to their Notes and comments. Hit **Sync** to fetch activity. The first sync may take several minutes while the database builds — this is normal.
+- **Publication tabs** — comments on their own posts. Hit **Load posts** first, then **Sync** for ongoing updates.
+- **Liked toggle** — when on, liked replies move to a collapsed "handled" section.
+- **Search** — filters across all tabs simultaneously.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,11 @@ Ask the user:
 
 **If just trying it out (clone):**
 
+Ask where they'd like to put it — their Desktop, Documents, or a Projects folder all work. Then clone there:
+
 ```bash
-mkdir -p ~/Projects
-cd ~/Projects
-git clone https://github.com/alyssafuward/substack-replies.git
-cd substack-replies
+git clone https://github.com/alyssafuward/substack-replies.git /path/they/chose/substack-replies
+cd /path/they/chose/substack-replies
 pip install -r requirements.txt
 ```
 
@@ -52,13 +52,11 @@ pip install -r requirements.txt
 If they don't have a GitHub account, tell them to create one at github.com. Then:
 
 1. Tell them to go to https://github.com/alyssafuward/substack-replies and click **Fork** → **Create fork**
-2. Ask for their GitHub username, then:
+2. Ask for their GitHub username and where they'd like to put it, then:
 
 ```bash
-mkdir -p ~/Projects
-cd ~/Projects
-git clone https://github.com/THEIR-USERNAME/substack-replies.git
-cd substack-replies
+git clone https://github.com/THEIR-USERNAME/substack-replies.git /path/they/chose/substack-replies
+cd /path/they/chose/substack-replies
 pip install -r requirements.txt
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,80 +17,81 @@ If it's missing or expired:
 
 ## First-time setup (new user, no config.py)
 
-If `config.py` doesn't exist, follow these steps in order.
+Walk through this interactively — one step at a time. Do not present all the steps upfront. Complete each step, confirm it worked, then move to the next.
 
-### 1. Check prerequisites
+---
+
+**Step 1: Check prerequisites.** Run these and show the user the results:
 
 ```bash
 python3 --version
 git --version
 ```
 
-If Python 3 isn't installed, tell the user to download it from python.org and come back. On Mac, if Git isn't installed, `git --version` may trigger a prompt to install Xcode Command Line Tools — warn them it's safe.
+If Python 3 isn't installed, tell them to download it from python.org and come back before continuing. On Mac, if Git isn't installed, running `git --version` may trigger a prompt to install Xcode Command Line Tools — warn them this might happen and that it's safe to install. Once both are confirmed, move to step 2.
 
-### 2. Fork or clone?
+---
 
-Ask the user:
+**Step 2: Fork or clone?** Ask this before doing anything else:
 
-> Quick question before we download the app: do you think you might want to customize it — change how it looks, what it tracks, how things are organized? Or do you just want to try it out as-is?
+> Quick question before we download the app: do you think you might want to customize it at some point — change how it looks, what it tracks, how things are organized? Or do you just want to try it out as-is?
 >
 > - **Just try it out** → simple download, no GitHub account needed.
-> - **I want to customize it** → we'll set up your own copy on GitHub. You'll need a free GitHub account.
+> - **I want to customize it** → we'll set up your own copy on GitHub that you can modify. You'll need a free GitHub account.
 
-**If just trying it out (clone):**
+Wait for their answer, then continue.
 
-Ask where they'd like to put it — their Desktop, Documents, or a Projects folder all work. Then clone there:
+**If just trying it out:** Ask where they'd like to keep the app — Desktop, Documents, and home directory all work fine. Then clone there and install dependencies:
 
 ```bash
-git clone https://github.com/alyssafuward/substack-replies.git /path/they/chose/substack-replies
-cd /path/they/chose/substack-replies
+git clone https://github.com/alyssafuward/substack-replies.git ~/Desktop/substack-replies
 pip install -r requirements.txt
 ```
 
-**If they want to customize (fork + clone):**
+(Replace the path with wherever they chose.)
 
-If they don't have a GitHub account, tell them to create one at github.com. Then:
+**If they want to customize:** If they don't have a GitHub account, tell them to create one at github.com — it's free. Once they have one, tell them to:
+1. Go to https://github.com/alyssafuward/substack-replies
+2. Click **Fork** → **Create fork**
 
-1. Tell them to go to https://github.com/alyssafuward/substack-replies and click **Fork** → **Create fork**
-2. Ask for their GitHub username and where they'd like to put it, then:
+Then ask for their GitHub username and where they'd like to keep the app, and clone their fork:
 
 ```bash
-git clone https://github.com/THEIR-USERNAME/substack-replies.git /path/they/chose/substack-replies
-cd /path/they/chose/substack-replies
+git clone https://github.com/THEIR-USERNAME/substack-replies.git ~/Desktop/substack-replies
 pip install -r requirements.txt
 ```
 
-### 3. Get the Substack session cookie
+Confirm the clone and install succeeded before continuing.
 
-The user does this themselves — **do not have them paste the cookie value into chat**. Conversation content is sent to Anthropic's servers and the cookie is a live credential.
+---
 
-Tell the user:
+**Step 3: Substack session cookie.** Tell the user this before anything else:
 
-> This is the one part I can't do for you. A session cookie is how your browser proves to Substack that you're logged in — we need it so the app can fetch your data. Don't share it with anyone, including me. I'll give you a command to store it safely on your machine.
+> This is the one part I can't do for you — and you should not paste the value into this chat. A session cookie is how your browser proves to Substack that you're logged in. We need it so the app can fetch your data on your behalf. Treat it like a password. I'll give you a command to store it safely on your machine.
 
-Walk them through finding it:
-1. Open [substack.com](https://substack.com) logged in
-2. Open DevTools: `Cmd+Option+I` (Mac) or `F12` (Windows)
-3. Click **Application** tab → **Cookies** → `https://substack.com`
-4. Find `substack.sid` and copy its value
+Then walk them through finding it:
+1. Open [substack.com](https://substack.com) in their browser, logged in
+2. Open DevTools: `Cmd+Option+I` on Mac, `F12` on Windows
+3. Click the **Application** tab → **Cookies** → `https://substack.com`
+4. Find the row named `substack.sid` and copy the value
 
-Give them this command to run in Terminal (they replace the placeholder with their value):
+Tell them to run this command in Terminal, replacing the placeholder with the value they copied:
 
 ```bash
 echo 'export SUBSTACK_SID="paste-your-value-here"' >> ~/.zshrc && source ~/.zshrc
 ```
 
-Verify it took:
+Then verify it's set:
 
 ```bash
 echo $SUBSTACK_SID
 ```
 
-If it prints nothing, troubleshoot — they may be on a different shell (`echo $SHELL`).
+If it prints nothing, troubleshoot before continuing — they may be using a different shell (check with `echo $SHELL`).
 
-### 4. Look up their account details
+---
 
-Once `SUBSTACK_SID` is set, fetch their user ID and handle automatically:
+**Step 4: Look up their account details.** Run this to fetch their user ID and handle:
 
 ```python
 import requests, os
@@ -107,9 +108,11 @@ print(f"USER_ID: {data.get('id') or data.get('user_id')}")
 print(f"HANDLE: {data.get('handle', '')}")
 ```
 
-### 5. Get publication IDs
+Note the USER_ID and HANDLE values for the next step.
 
-Ask for the subdomain(s) of their Substack publication(s) — the part before `.substack.com`. For each one:
+---
+
+**Step 5: Publication IDs.** Ask: "What's the subdomain of your Substack publication — the part before `.substack.com`?" For each subdomain they give you:
 
 ```python
 import requests, os
@@ -126,7 +129,9 @@ data = resp.json()
 print(f"{subdomain}: {data.get('id')}")
 ```
 
-### 6. Create config.py
+---
+
+**Step 6: Create config.py.** Write this file with the values from steps 4 and 5:
 
 ```python
 USER_ID = <user_id>
@@ -138,26 +143,34 @@ OWN_PUBS = {
 }
 ```
 
-### 7. Verify and run
+---
+
+**Step 7: Verify.** Run the integrity check:
 
 ```bash
 python check.py
 ```
 
-If any checks fail, diagnose before continuing. Then start the app:
+If any checks fail, diagnose and fix before continuing.
+
+---
+
+**Step 8: Start the app.**
 
 ```bash
 python app.py
 ```
 
-Tell the user to open http://localhost:5001. Explain that this is local to their computer — it's not a website anyone else can see.
+Tell the user to open http://localhost:5001 in their browser. Explain that this address is local to their computer — it's not a website anyone else can see.
 
-### 8. Walk them through first use
+---
 
-- **Replies tab** — replies to their Notes and comments. Hit **Sync** to fetch activity. The first sync may take several minutes while the database builds — this is normal.
-- **Publication tabs** — comments on their own posts. Hit **Load posts** first, then **Sync** for ongoing updates.
-- **Liked toggle** — when on, liked replies move to a collapsed "handled" section.
-- **Search** — filters across all tabs simultaneously.
+**Step 9: First use.** Walk them through what they're looking at:
+
+- **Replies tab** — replies to their Substack Notes and comments. Hit **Sync** to fetch their activity. The first sync builds the database and may take several minutes — this is normal.
+- **Publication tabs** — comments on their own posts. Hit **Load posts** first to pull them in, then **Sync** for ongoing updates.
+- **Liked toggle** — when on, items you've liked on Substack move to a collapsed "handled" section instead of staying in your queue.
+- **Search** — filters across all tabs simultaneously by name, keyword, or phrase.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ This is not a managed service. It runs locally on your computer, stores your dat
 
 ## Getting started
 
-**[Download the setup skill](https://raw.githubusercontent.com/alyssafuward/substack-replies/main/setup-skill/SKILL.md)** — right-click and Save As, or click Raw and use your browser's save option. Drop it in your Downloads folder. Then open Claude Code and say:
+**[Read the setup guide](SETUP.md)** — it walks you through everything. The short version:
 
-> "Install the setup skill from my Downloads folder"
+1. Install [Claude Code](https://claude.ai/code) if you haven't already
+2. Open Terminal, type `claude`, and press Enter
+3. Paste this into the Claude conversation:
 
-Claude will walk you through everything: installing Python if needed, getting a copy of the code, setting up a GitHub account if you want one, getting your Substack credentials, configuring the app, and verifying it all works before you run it for the first time.
+> I want to set up this Substack replies tool: https://github.com/alyssafuward/substack-replies — can you clone it, install what's needed, and walk me through the setup?
 
-**A note on Terminal.** Claude Code runs inside Terminal. If you haven't used it before — on a Mac, press `Cmd+Space`, type "Terminal", and hit enter. One thing that trips people up: Terminal is keyboard-only. You can't click to reposition your cursor inside a command the way you would in a text editor. Use the arrow keys to move around and edit. Claude will give you exact commands to run, so mostly you'll just be pasting (`Cmd+V`) and hitting enter.
+Claude will ask whether you want to just try the app or create your own copy on GitHub, then handle the download, dependencies, and configuration for you.
+
+**A note on Terminal.** Claude Code runs inside Terminal. If you haven't used it before — on a Mac, press `Cmd+Space`, type "Terminal", and hit enter. One thing that trips people up: Terminal is keyboard-only. You can't click to reposition your cursor inside a command. Use the arrow keys to move around and edit. Claude will give you exact commands to run, so mostly you'll just be pasting (`Cmd+V`) and hitting enter.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,72 @@
+# Setting Up Substack Replies
+
+Substack Replies is a local tool that pulls all your Substack replies and comments into a single dashboard so you can track which ones need a response. This guide walks you through getting it running on your computer. You don't need to be a developer — Claude Code will handle the technical parts for you.
+
+---
+
+## What you'll need
+
+- A Mac or PC
+- A Substack account
+- About 10–15 minutes
+
+---
+
+## Step 1: Install Claude Code
+
+Claude Code is an AI assistant that runs in your Terminal. It will set up and run this tool for you — you just tell it what you want in plain language.
+
+Follow the official installation instructions at: **[claude.ai/code](https://claude.ai/code)**
+
+---
+
+## Step 2: Open Terminal and start Claude Code
+
+Terminal is a text-based interface that lets you run commands on your computer. Claude Code runs inside Terminal and issues commands on your behalf. Before running anything, it will show you what it's about to do and ask for your permission.
+
+**To open Terminal on a Mac:**
+1. Press **Cmd+Space** to open Spotlight
+2. Type "Terminal" and press Enter
+
+Then type the following and press Enter:
+
+```
+claude
+```
+
+> **If you're not a developer:** tell Claude at the start: *"I'm not a developer — please explain what you're doing and ask before running anything."* If Claude asks to do something you don't understand or that seems unrelated to setting up this tool, say no and ask it to explain first.
+
+---
+
+## Step 3: Tell Claude to set up Substack Replies
+
+Paste this into the Claude conversation:
+
+> I want to set up this Substack replies tool: https://github.com/alyssafuward/substack-replies — can you clone it, install what's needed, and walk me through the setup?
+
+Claude will ask whether you want to just try the app as-is, or create your own copy on GitHub so you can customize it later. Either way, it will handle the download, dependencies, and configuration for you.
+
+---
+
+## Step 4: Get your Substack session cookie
+
+At some point Claude will ask for your Substack session cookie. This is the credential the app uses to fetch your data from Substack on your behalf.
+
+**Treat your session cookie like a password.** Do not paste it into the Claude chat — Claude will tell you how to store it safely on your machine instead.
+
+To find your cookie:
+1. Open [substack.com](https://substack.com) in your browser, logged in
+2. Open Developer Tools: **Cmd+Option+I** on Mac, **F12** on Windows
+3. Click the **Application** tab (Chrome) or **Storage** tab (Firefox)
+4. In the left sidebar: **Cookies** → **https://substack.com**
+5. Find the row named `substack.sid` and copy its value
+
+Claude will give you a command to store it securely — paste the command into Terminal, not the cookie value into chat.
+
+Once the cookie is set, Claude will run your first sync and open the dashboard. Building the database for the first time can take several minutes — this is normal. Subsequent syncs are much faster.
+
+---
+
+## Questions?
+
+Find me on Substack: [alyssafuward.substack.com](https://alyssafuward.substack.com)


### PR DESCRIPTION
## Summary

- Replaces the skill-download onboarding flow with a simpler entry point: user opens Claude Code, pastes the repo URL, and Claude handles everything
- **SETUP.md** (new) — human-readable guide covering what to expect, Terminal basics, and how to find your session cookie safely
- **CLAUDE.md** — expanded first-time setup section: fork-vs-clone decision tree, prerequisites check, credential step with security warning, account lookup scripts, config.py generation, and first-use walkthrough
- **README.md** — updated "Getting started" to use the URL approach instead of the old skill-download instructions

## Test plan

- [ ] Read through SETUP.md as a non-developer and check it's clear end-to-end
- [ ] Read through CLAUDE.md first-time setup section — does Claude have everything it needs to drive the flow?
- [ ] Check README "Getting started" reads cleanly and the prompt text is something you'd actually paste
- [ ] Verify SETUP.md isn't in .gitignore (it shouldn't be, but worth checking)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)