### PR TITLE
Sync and store all authored Substack Notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 replies.db*
 .env
 config.py
+*.bak
 *.json
 __pycache__/
 *.pyc

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ import threading
 from pathlib import Path
 from flask import Flask, Response, request, redirect, jsonify
 
-from dashboard import load_data, load_stats, load_post_comments_data, load_responded_data, load_archived_data, render_html
+from dashboard import load_data, load_stats, load_post_comments_data, load_responded_data, load_archived_data, load_notes_data, render_html
 from scraper import init_db, load_next_post, refresh_post_comments
 from insights import load_all as load_insights, render_insights_html, search_commenter
 
@@ -134,7 +134,7 @@ def sync_status():
 
 @app.route("/sync")
 def sync():
-    count = request.args.get("count", 250, type=int)
+    count = request.args.get("count", 150, type=int)
     cmd = [sys.executable, "-u", "scraper.py", "sync", "--count", str(count)]
     return Response(_stream(cmd), mimetype="text/event-stream", headers=_SSE_HEADERS)
 
@@ -225,12 +225,14 @@ def index():
         all_posts_data = {pub: load_post_comments_data(conn, pub) for pub in all_pubs}
         responded_items = load_responded_data(conn)
         archived_items = load_archived_data(conn)
+        notes_data = load_notes_data(conn)
 
     html = render_html(items, stats, all_posts_data=all_posts_data,
                        active_tab=active_tab, all_pubs=all_pubs,
                        responded_items=responded_items,
                        archived_items=archived_items,
-                       liked_acknowledged=liked_ack)
+                       liked_acknowledged=liked_ack,
+                       notes_data=notes_data)
     return Response(html, mimetype="text/html")
 
 
@@ -267,8 +269,7 @@ def render_empty():
         <option value="25" selected>25</option>
         <option value="50">50</option>
         <option value="100">100</option>
-        <option value="200">200</option>
-        <option value="250">250</option>
+        <option value="150">150</option>
       </select>
       <button class="sync-btn" id="sync-btn" onclick="startSync()">Sync</button>
       <button class="sync-btn" id="stop-btn" onclick="stopSync()" style="display:none; background:#888;">Stop</button>

--- a/app.py
+++ b/app.py
@@ -211,9 +211,17 @@ def insights():
 
 @app.route("/")
 def index():
+    """Returns instantly with a loading shell, which immediately fetches the
+    real dashboard from /dashboard-data and swaps it in — so there's visible
+    feedback the moment the page opens, rather than a blank tab while the
+    server does its (still not instant, for a big history) work."""
     if not DB_PATH.exists():
         return Response(render_empty(), mimetype="text/html")
+    return Response(render_loading_shell(), mimetype="text/html")
 
+
+@app.route("/dashboard-data")
+def dashboard_data():
     from config import OWN_PUBS
     all_pubs = list(OWN_PUBS.keys())
     active_tab = request.args.get("tab", "replies")
@@ -234,6 +242,44 @@ def index():
                        liked_acknowledged=liked_ack,
                        notes_data=notes_data)
     return Response(html, mimetype="text/html")
+
+
+def render_loading_shell():
+    return """<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Substack Replies</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<style>
+  body { font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+         background: #F2F8FD; color: #1A1A1A; height: 100vh; margin: 0;
+         display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 12px; }
+  .loading-title { font-family: 'DM Serif Display', Georgia, serif; font-size: 1.4rem; }
+  @keyframes envelope-fly {
+    0%   { transform: translate(-40px, 0) rotate(0deg); opacity: 0; }
+    10%  { opacity: 1; }
+    40%  { transform: translate(80px, 0) rotate(0deg); }
+    55%  { transform: translate(115px, -50px) rotate(180deg); }
+    70%  { transform: translate(150px, 0) rotate(360deg); }
+    90%  { opacity: 1; }
+    100% { transform: translate(240px, 0) rotate(360deg); opacity: 0; }
+  }
+</style></head>
+<body>
+  <div class="loading-title">Substack Replies</div>
+  <div style="width:240px; height:90px; overflow:hidden; position:relative;">
+    <div style="position:absolute; top:55px; left:0; font-size:28px; line-height:32px; animation:envelope-fly 3s ease-in-out infinite;">✉️</div>
+  </div>
+  <div style="font-size:0.85rem; color:#666;">Loading your replies…</div>
+  <script>
+    fetch('/dashboard-data' + window.location.search)
+      .then(r => r.text())
+      .then(html => { document.open(); document.write(html); document.close(); })
+      .catch(() => {
+        document.body.innerHTML = '<p>Something went wrong loading the dashboard. <a href="' + window.location.href + '">Try again</a>.</p>';
+      });
+  </script>
+</body></html>"""
 
 
 def render_empty():

--- a/dashboard.py
+++ b/dashboard.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from datetime import datetime
 
 try:
-    from config import USER_ID, OWN_PUBS
+    from config import USER_ID, OWN_PUBS, HANDLE
 except ImportError:
     print("Error: config.py not found. Copy config.example.py to config.py and fill in your values.")
     sys.exit(1)
@@ -455,6 +455,35 @@ def load_post_comments_data(conn, pub_subdomain):
     return result
 
 
+def load_notes_data(conn):
+    """Return your authored Notes: standalone notes and replies you made in others' note threads.
+    Notes are stored in the comments table with post_id/pub_subdomain NULL, since they
+    aren't tied to a post; populated by `scraper.py sync` via sync_my_notes()."""
+    rows = conn.execute("""
+        SELECT id, body, date, ancestor_path, raw_json
+        FROM comments
+        WHERE user_id=? AND post_id IS NULL AND pub_subdomain IS NULL
+        ORDER BY date DESC
+    """, (USER_ID,)).fetchall()
+
+    standalone = []
+    thread_replies = []
+    for cid, body, date, ancestor_path, raw_json_str in rows:
+        raw = json.loads(raw_json_str or "{}")
+        note = {
+            "id": cid,
+            "body": body or "",
+            "date": (date or "")[:10],
+            "raw_date": date or "",
+            "link": f"https://substack.com/@{HANDLE}/note/c-{cid}",
+            "reaction_count": raw.get("reaction_count") or 0,
+            "restacks": raw.get("restacks") or 0,
+        }
+        (thread_replies if ancestor_path else standalone).append(note)
+
+    return {"standalone": standalone, "thread_replies": thread_replies}
+
+
 # ── HTML ──────────────────────────────────────────────────────────────────────
 
 def escape(s):
@@ -686,11 +715,75 @@ def render_post_comments_tab(posts_data, pub_subdomain, liked_acknowledged=True)
   {empty_html}"""
 
 
-def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pubs=None, responded_items=None, archived_items=None, liked_acknowledged=True):
+def render_note_card(n):
+    date = escape(format_date(n.get("raw_date", n["date"])))
+    LIMIT = 220
+    raw_body = n["body"]
+    if len(raw_body) <= LIMIT:
+        body_html = escape(raw_body)
+    else:
+        short = escape(raw_body[:LIMIT])
+        full = escape(raw_body)
+        body_html = f'<span class="thread-short">{short}<button class="thread-more" onclick="expandThread(this)">… more</button></span><span class="thread-full" style="display:none">{full}<button class="thread-more" onclick="collapseThread(this)"> less</button></span>'
+    link = n.get("link", "")
+    meta_bits = []
+    if n.get("reaction_count"):
+        meta_bits.append(f"❤️ {n['reaction_count']}")
+    if n.get("restacks"):
+        meta_bits.append(f"🔁 {n['restacks']}")
+    meta_html = f'<span class="liked-badge">{" · ".join(meta_bits)}</span>' if meta_bits else ""
+    link_html = f'<a href="{escape(link)}" target="_blank" class="reply-link">Open →</a>' if link else ""
+
+    return f"""    <div class="post-comment-card" data-date="{n.get('date','')}">
+      <div class="card-header">
+        <div class="card-meta">{meta_html}<span class="date">{date}</span></div>
+        <div class="card-actions">{link_html}</div>
+      </div>
+      <div class="their-content">{body_html}</div>
+    </div>"""
+
+
+def render_notes_tab(notes_data):
+    standalone = notes_data.get("standalone", [])
+    thread_replies = notes_data.get("thread_replies", [])
+
+    if not standalone and not thread_replies:
+        return """  <div class="posts-controls">
+    <div style="font-size:0.82rem; color:#888;">Notes are pulled in automatically whenever you hit Sync on the Replies tab.</div>
+  </div>
+  <div class="empty" style="margin-top:40px;">No Notes synced yet — click Sync on the Replies tab to fetch them.</div>"""
+
+    total = len(standalone)
+    banner_html = f'<div class="count-banner" style="margin-bottom:16px;">📝 <span id="notes-count">{total}</span> {"Note" if total == 1 else "Notes"} written</div>'
+    cards_html = "\n".join(render_note_card(n) for n in standalone)
+
+    replies_toggle = ""
+    if thread_replies:
+        replies_html = "\n".join(render_note_card(n) for n in thread_replies)
+        replies_toggle = f"""
+  <div class="toggle-section" id="notes-replies-toggle-wrap">
+    <button class="toggle-btn" onclick="toggleSection(this)">▶ Replies to others' notes (<span id="notes-replies-count">{len(thread_replies)}</span>)</button>
+    <div class="liked-section" id="notes-replies-section">
+      <div class="cards" id="notes-replies-cards">{replies_html}</div>
+    </div>
+  </div>"""
+
+    return f"""  <div class="posts-controls">
+    <div style="font-size:0.82rem; color:#888;">Notes are pulled in automatically whenever you hit Sync on the Replies tab.</div>
+  </div>
+  {banner_html}
+  <div class="cards" id="notes-cards">
+    {cards_html}
+  </div>
+  {replies_toggle}"""
+
+
+def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pubs=None, responded_items=None, archived_items=None, liked_acknowledged=True, notes_data=None):
     all_posts_data = all_posts_data or {}
     all_pubs = all_pubs or []
     responded_items = responded_items or []
     archived_items = archived_items or []
+    notes_data = notes_data or {"standalone": [], "thread_replies": []}
 
     if liked_acknowledged:
         needs_response = [i for i in items if not i.get("liked") and i.get("source") != "own_pub"]
@@ -955,6 +1048,7 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
 
   <div class="tab-nav">
     <button class="tab-btn" id="tab-btn-replies" data-label="Replies" onclick="switchTab('replies')">Replies</button>
+    <button class="tab-btn" id="tab-btn-notes" data-label="Notes" onclick="switchTab('notes')">Notes</button>
     {pub_tabs_html}
   </div>
 
@@ -998,12 +1092,17 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
     {"<div class='toggle-section' id='archived-toggle-wrap'><button class='toggle-btn' onclick='toggleArchived(this)'>▶ Archived (<span id='archived-count'>" + str(archived_count) + "</span>)</button><div class='liked-section' id='archived-section'><div class='cards' id='archived-cards'>" + archived_cards + "</div></div></div>" if archived_count else ""}
   </div>
 
+  <div id="tab-content-notes" style="display:none">
+    {render_notes_tab(notes_data)}
+  </div>
+
   {pub_contents_html}
 
   <script>
     const initTab = "{active_tab}";
 
     const allPubs = {json.dumps(all_pubs)};
+    const allTabs = allPubs.concat(['notes']);
 
     function showReloadOverlay() {{
       const overlay = document.getElementById('page-loading');
@@ -1020,7 +1119,7 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
     function switchTab(tab) {{
       // Hide all tabs
       document.getElementById('tab-replies').style.display = 'none';
-      allPubs.forEach(p => {{
+      allTabs.forEach(p => {{
         const el = document.getElementById('tab-content-' + p);
         if (el) el.style.display = 'none';
         const btn = document.getElementById('tab-btn-' + p);
@@ -1314,6 +1413,17 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
       }});
 
       setTabLabel('replies', hasFilter ? repliesTotal : null);
+
+      // ── Notes tab ──
+      {{
+        let notesTotal = 0;
+        document.querySelectorAll('#notes-cards .post-comment-card, #notes-replies-cards .post-comment-card').forEach(card => {{
+          const show = cardMatches(card, '', keyQ, dateFrom, dateTo);
+          card.style.display = show ? '' : 'none';
+          if (show) notesTotal++;
+        }});
+        setTabLabel('notes', hasFilter ? notesTotal : null);
+      }}
 
       // ── Pub tabs ──
       allPubs.forEach(pub => {{

--- a/dashboard.py
+++ b/dashboard.py
@@ -28,35 +28,121 @@ def _comment_link(post_url, comment_id):
 
 
 # ── Data ──────────────────────────────────────────────────────────────────────
+#
+# The loaders below batch what used to be per-row queries (one LIKE scan or
+# id lookup per activity item / comment) into a handful of queries per page
+# load, using preloaded in-memory indexes for the per-item checks. See #63.
 
-def load_thread(conn, reply_id):
-    """Return ancestor comments in order (oldest first), excluding the reply itself."""
-    row = conn.execute("SELECT ancestor_path FROM comments WHERE id=?", (reply_id,)).fetchone()
-    if not row or not row[0]:
-        return []
-    ancestor_ids = [int(x) for x in row[0].split(".") if x]
-    if not ancestor_ids:
-        return []
-    placeholders = ",".join("?" * len(ancestor_ids))
-    rows = conn.execute(
-        f"SELECT id, name, body, post_url, handle FROM comments WHERE id IN ({placeholders})", ancestor_ids
+def _load_own_replies(conn):
+    """Index of {ancestor_id: [(own_comment_id, own_comment_body), ...]} for
+    every comment USER_ID has made that is itself a reply — built by
+    splitting each reply's dot-delimited ancestor_path into its component
+    ids. Preloaded once per request so "has the user already replied
+    somewhere under X" is an O(1) dict lookup instead of a per-item LIKE
+    query (which can't use an index and does a full table scan every time)."""
+    rows = conn.execute("""
+        SELECT id, ancestor_path, body FROM comments
+        WHERE user_id=? AND ancestor_path IS NOT NULL AND ancestor_path != ''
+    """, (USER_ID,)).fetchall()
+    index = {}
+    for oid, path, body in rows:
+        for part in path.split("."):
+            if not part:
+                continue
+            try:
+                aid = int(part)
+            except ValueError:
+                continue
+            index.setdefault(aid, []).append((oid, body))
+    return index
+
+
+def _load_own_comment_ids(conn):
+    """Every comment id authored by USER_ID, for O(1) 'is this ancestor mine' checks."""
+    return {r[0] for r in conn.execute("SELECT id FROM comments WHERE user_id=?", (USER_ID,)).fetchall()}
+
+
+def _replied_after(own_replies_index, reply_id):
+    """Is there a reply of yours, later than reply_id, somewhere under it."""
+    return any(oid > reply_id for oid, _body in own_replies_index.get(reply_id, ()))
+
+
+def _reply_back_body(own_replies_index, reply_id):
+    """Body of your earliest reply, later than reply_id, under it."""
+    matches = [(oid, body) for oid, body in own_replies_index.get(reply_id, ()) if oid > reply_id]
+    if not matches:
+        return ""
+    matches.sort(key=lambda x: x[0])
+    return matches[0][1] or ""
+
+
+def _replied_under(own_replies_index, cid):
+    """Have you replied anywhere under cid."""
+    return cid in own_replies_index
+
+
+def _fetch_comments_by_id(conn, ids):
+    """Batch fetch of {id: (name, handle, body, post_id, post_url, raw_json)}."""
+    ids = list({i for i in ids if i})
+    if not ids:
+        return {}
+    placeholders = ",".join("?" * len(ids))
+    rows = conn.execute(f"""
+        SELECT id, name, handle, body, post_id, post_url, raw_json
+        FROM comments WHERE id IN ({placeholders})
+    """, ids).fetchall()
+    return {r[0]: r[1:] for r in rows}
+
+
+def _load_threads_batch(conn, ids):
+    """Return {id: thread} for many reply ids in at most 2 queries total,
+    instead of load_thread's 2 queries times N calls."""
+    ids = list({i for i in ids if i})
+    if not ids:
+        return {}
+    placeholders = ",".join("?" * len(ids))
+    path_rows = conn.execute(
+        f"SELECT id, ancestor_path FROM comments WHERE id IN ({placeholders})", ids
     ).fetchall()
-    by_id = {r[0]: r for r in rows}
-    result = []
-    for i in ancestor_ids:
-        if i not in by_id:
-            continue
-        _, name, body, post_url, handle = by_id[i]
-        link = _comment_link(post_url, i)
-        if not link and handle:
-            link = f"https://substack.com/@{handle}/note/c-{i}"
-        result.append({"id": i, "name": name or "?", "body": body or "", "link": link})
-    return result
+    paths = dict(path_rows)
+
+    parsed = {}
+    all_ancestor_ids = set()
+    for rid in ids:
+        path = paths.get(rid)
+        ancestor_ids = [int(x) for x in path.split(".") if x] if path else []
+        parsed[rid] = ancestor_ids
+        all_ancestor_ids.update(ancestor_ids)
+
+    by_id = {}
+    if all_ancestor_ids:
+        a_list = list(all_ancestor_ids)
+        a_placeholders = ",".join("?" * len(a_list))
+        rows = conn.execute(
+            f"SELECT id, name, body, post_url, handle FROM comments WHERE id IN ({a_placeholders})", a_list
+        ).fetchall()
+        by_id = {r[0]: r for r in rows}
+
+    threads = {}
+    for rid in ids:
+        thread = []
+        for aid in parsed[rid]:
+            if aid not in by_id:
+                continue
+            _, name, body, post_url, handle = by_id[aid]
+            link = _comment_link(post_url, aid)
+            if not link and handle:
+                link = f"https://substack.com/@{handle}/note/c-{aid}"
+            thread.append({"id": aid, "name": name or "?", "body": body or "", "link": link})
+        threads[rid] = thread
+    return threads
 
 
 def load_data(conn):
     """Return list of dicts representing replies needing response."""
     results = []
+    own_replies = _load_own_replies(conn)
+    own_comment_ids = _load_own_comment_ids(conn)
 
     # 1. Note/comment replies from activity feed
     rows = conn.execute("""
@@ -67,30 +153,25 @@ def load_data(conn):
         ORDER BY a.created_at DESC
     """).fetchall()
 
+    candidates = []
     for row in rows:
         item_id, item_type, created_at, reply_id, your_id, raw, is_responded = row
         if not reply_id or (not your_id and item_type != 'comment_mention'):
             continue
-
-        # Check if you already replied back (recheck flag or response comment in DB)
         if is_responded:
             continue
-        your_reply = conn.execute("""
-            SELECT id FROM comments
-            WHERE user_id = ? AND ancestor_path LIKE ? AND id > ?
-        """, (USER_ID, f"%{reply_id}%", reply_id)).fetchone()
-        if your_reply:
+        if _replied_after(own_replies, reply_id):
             continue
+        candidates.append((item_type, created_at, reply_id, your_id))
 
-        reply_row = conn.execute(
-            "SELECT name, handle, body, post_id, post_url, raw_json FROM comments WHERE id=?", (reply_id,)
-        ).fetchone()
-        your_row = conn.execute(
-            "SELECT body FROM comments WHERE id=?", (your_id,)
-        ).fetchone() if your_id else None
+    comment_rows = _fetch_comments_by_id(conn, [c[2] for c in candidates] + [c[3] for c in candidates if c[3]])
+    threads = _load_threads_batch(conn, [c[2] for c in candidates])
 
+    for item_type, created_at, reply_id, your_id in candidates:
+        reply_row = comment_rows.get(reply_id)
         if not reply_row:
             continue
+        your_row = comment_rows.get(your_id) if your_id else None
 
         name = reply_row[0] or reply_row[1] or "Someone"
         reply_handle = reply_row[1] or ""
@@ -98,7 +179,7 @@ def load_data(conn):
         post_id = reply_row[3]
         post_url = reply_row[4]
         reply_raw = json.loads(reply_row[5] or "{}")
-        your_body = your_row[0] if your_row else ""
+        your_body = your_row[2] if your_row else ""
         if item_type == "note_reply":
             label = "replied to your note"
         elif item_type == "comment_mention":
@@ -116,7 +197,7 @@ def load_data(conn):
         else:
             link = ""
 
-        thread = load_thread(conn, reply_id)
+        thread = threads.get(reply_id, [])
         guest_post = bool(post_url) and not any(f"{sub}.substack.com" in post_url for sub in OWN_PUBS)
 
         results.append({
@@ -138,7 +219,7 @@ def load_data(conn):
     # 2. Unresponded comments on own posts
     rows = conn.execute("""
         SELECT c.id, c.name, c.handle, c.body, c.date,
-               c.post_title, c.post_url, c.ancestor_path, c.post_id
+               c.post_title, c.post_url, c.ancestor_path, c.post_id, c.raw_json
         FROM comments c
         WHERE c.pub_subdomain IS NOT NULL
           AND c.user_id != ?
@@ -146,36 +227,31 @@ def load_data(conn):
         ORDER BY c.date DESC
     """, (USER_ID,)).fetchall()
 
+    own_pub_candidates = []
     for row in rows:
-        cid, name, handle, body, date, post_title, post_url, ancestor_path, post_id = row
+        cid, name, handle, body, date, post_title, post_url, ancestor_path, post_id, raw_json_str = row
 
-        your_reply = conn.execute("""
-            SELECT id FROM comments
-            WHERE user_id = ? AND (ancestor_path = ? OR ancestor_path LIKE ?)
-        """, (USER_ID, str(cid), f"%.{cid}%")).fetchone()
-        if your_reply:
+        if _replied_under(own_replies, cid):
             continue
 
         if ancestor_path:
             ancestor_ids = [int(x) for x in ancestor_path.split(".") if x]
-            if ancestor_ids:
-                your_in_thread = conn.execute(
-                    f"SELECT id FROM comments WHERE user_id=? AND id IN ({','.join('?'*len(ancestor_ids))})",
-                    [USER_ID] + ancestor_ids
-                ).fetchone()
-                if not your_in_thread:
-                    continue
+            if ancestor_ids and not any(a in own_comment_ids for a in ancestor_ids):
+                continue
 
+        own_pub_candidates.append((cid, name, handle, body, date, post_title, post_url, raw_json_str))
+
+    threads = _load_threads_batch(conn, [c[0] for c in own_pub_candidates])
+
+    for cid, name, handle, body, date, post_title, post_url, raw_json_str in own_pub_candidates:
         link = post_url or ""
         if link and cid:
             link = f"{link.rstrip('/')}/comment/{cid}"
 
-        # Check if you liked this comment
-        liked_row = conn.execute("SELECT raw_json FROM comments WHERE id=?", (cid,)).fetchone()
-        liked_raw = json.loads(liked_row[0] or "{}") if liked_row else {}
+        liked_raw = json.loads(raw_json_str or "{}")
         liked = bool(liked_raw.get("reaction"))
 
-        thread = load_thread(conn, cid)
+        thread = threads.get(cid, [])
 
         results.append({
             "source": "own_pub",
@@ -195,29 +271,34 @@ def load_data(conn):
     return results
 
 
-def load_responded_data(conn):
-    """Return activity reply items where you have responded."""
+def _load_activity_replies(conn, filter_clause, include_reply_back):
+    """Shared by load_responded_data / load_archived_data — same shape query,
+    different WHERE clause and (for responded) an extra reply-back lookup."""
     results = []
-    rows = conn.execute("""
+    own_replies = _load_own_replies(conn) if include_reply_back else None
+    rows = conn.execute(f"""
         SELECT a.id, a.type, a.created_at, a.comment_id, a.target_comment_id, a.raw_json
         FROM activity_items a
         WHERE a.type IN ('note_reply', 'comment_reply', 'comment_mention')
-          AND a.is_responded = 1
+          AND {filter_clause}
         ORDER BY a.created_at DESC
     """).fetchall()
 
+    candidates = []
     for row in rows:
         item_id, item_type, created_at, reply_id, your_id, raw = row
         if not reply_id or (not your_id and item_type != 'comment_mention'):
             continue
+        candidates.append((item_type, created_at, reply_id, your_id))
 
-        reply_row = conn.execute(
-            "SELECT name, handle, body, post_id, post_url, raw_json FROM comments WHERE id=?", (reply_id,)
-        ).fetchone()
-        your_row = conn.execute("SELECT body FROM comments WHERE id=?", (your_id,)).fetchone() if your_id else None
+    comment_rows = _fetch_comments_by_id(conn, [c[2] for c in candidates] + [c[3] for c in candidates if c[3]])
+    threads = _load_threads_batch(conn, [c[2] for c in candidates])
 
+    for item_type, created_at, reply_id, your_id in candidates:
+        reply_row = comment_rows.get(reply_id)
         if not reply_row:
             continue
+        your_row = comment_rows.get(your_id) if your_id else None
 
         name = reply_row[0] or reply_row[1] or "Someone"
         reply_handle = reply_row[1] or ""
@@ -225,21 +306,13 @@ def load_responded_data(conn):
         post_id = reply_row[3]
         post_url = reply_row[4]
         reply_raw = json.loads(reply_row[5] or "{}")
-        your_body = your_row[0] if your_row else ""
+        your_body = your_row[2] if your_row else ""
         if item_type == "note_reply":
             label = "replied to your note"
         elif item_type == "comment_mention":
             label = "mentioned you in a note"
         else:
             label = "replied to your comment"
-
-        # Find your reply back to this person
-        reply_back_row = conn.execute("""
-            SELECT body FROM comments
-            WHERE user_id = ? AND ancestor_path LIKE ? AND id > ?
-            ORDER BY id LIMIT 1
-        """, (USER_ID, f"%{reply_id}%", reply_id)).fetchone()
-        your_reply_back = reply_back_row[0] if reply_back_row else ""
 
         if item_type in ("note_reply", "comment_mention") and reply_handle:
             link = f"https://substack.com/@{reply_handle}/note/c-{reply_id}"
@@ -250,9 +323,9 @@ def load_responded_data(conn):
         else:
             link = ""
 
-        thread = load_thread(conn, reply_id)
+        thread = threads.get(reply_id, [])
 
-        results.append({
+        entry = {
             "source": "activity",
             "date": (created_at or "")[:10],
             "raw_date": created_at or "",
@@ -261,81 +334,26 @@ def load_responded_data(conn):
             "label": label,
             "your_body": your_body,
             "their_body": reply_body,
-            "your_reply_back": your_reply_back,
             "link": link,
             "comment_id": reply_id,
             "liked": bool(reply_raw.get("reaction")),
             "thread": thread,
-        })
+        }
+        if include_reply_back:
+            entry["your_reply_back"] = _reply_back_body(own_replies, reply_id)
+        results.append(entry)
 
     return results
+
+
+def load_responded_data(conn):
+    """Return activity reply items where you have responded."""
+    return _load_activity_replies(conn, "a.is_responded = 1", include_reply_back=True)
 
 
 def load_archived_data(conn):
     """Return activity reply items that have been archived."""
-    results = []
-    rows = conn.execute("""
-        SELECT a.id, a.type, a.created_at, a.comment_id, a.target_comment_id, a.raw_json
-        FROM activity_items a
-        WHERE a.type IN ('note_reply', 'comment_reply', 'comment_mention')
-          AND a.is_archived = 1
-        ORDER BY a.created_at DESC
-    """).fetchall()
-
-    for row in rows:
-        item_id, item_type, created_at, reply_id, your_id, raw = row
-        if not reply_id or (not your_id and item_type != 'comment_mention'):
-            continue
-
-        reply_row = conn.execute(
-            "SELECT name, handle, body, post_id, post_url, raw_json FROM comments WHERE id=?", (reply_id,)
-        ).fetchone()
-        your_row = conn.execute("SELECT body FROM comments WHERE id=?", (your_id,)).fetchone() if your_id else None
-
-        if not reply_row:
-            continue
-
-        name = reply_row[0] or reply_row[1] or "Someone"
-        reply_handle = reply_row[1] or ""
-        reply_body = reply_row[2] or ""
-        post_id = reply_row[3]
-        post_url = reply_row[4]
-        reply_raw = json.loads(reply_row[5] or "{}")
-        your_body = your_row[0] if your_row else ""
-        if item_type == "note_reply":
-            label = "replied to your note"
-        elif item_type == "comment_mention":
-            label = "mentioned you in a note"
-        else:
-            label = "replied to your comment"
-
-        if item_type in ("note_reply", "comment_mention") and reply_handle:
-            link = f"https://substack.com/@{reply_handle}/note/c-{reply_id}"
-        elif post_url:
-            link = f"{post_url.rstrip('/')}/comment/{reply_id}"
-        elif post_id:
-            link = f"https://substack.com/p/{post_id}/comment/{reply_id}"
-        else:
-            link = ""
-
-        thread = load_thread(conn, reply_id)
-
-        results.append({
-            "source": "activity",
-            "date": (created_at or "")[:10],
-            "raw_date": created_at or "",
-            "who": name,
-            "handle": reply_handle,
-            "label": label,
-            "your_body": your_body,
-            "their_body": reply_body,
-            "link": link,
-            "comment_id": reply_id,
-            "liked": bool(reply_raw.get("reaction")),
-            "thread": thread,
-        })
-
-    return results
+    return _load_activity_replies(conn, "a.is_archived = 1", include_reply_back=False)
 
 
 def _format_sync_time(iso_str):
@@ -388,10 +406,22 @@ def load_stats(conn):
         "gap_warning": gap_warning,
     }
 
+def _own_reply_body_under(own_replies_index, cid):
+    """Body of your earliest reply under cid. (If you replied more than once
+    to the same commenter, which one showed here was previously undefined —
+    the original query had no ORDER BY — so this picks deterministically.)"""
+    matches = own_replies_index.get(cid)
+    if not matches:
+        return ""
+    return min(matches, key=lambda m: m[0])[1] or ""
+
+
 def load_post_comments_data(conn, pub_subdomain):
     """Return loaded posts with their unanswered/liked comments for Tab 2."""
     if not pub_subdomain:
         return []
+
+    own_replies = _load_own_replies(conn)
 
     posts = conn.execute("""
         SELECT id, title, canonical_url, post_date
@@ -413,11 +443,6 @@ def load_post_comments_data(conn, pub_subdomain):
         responded_list = []
 
         for cid, name, handle, body, date, raw_json_str in comment_rows:
-            your_reply = conn.execute("""
-                SELECT id, body FROM comments
-                WHERE user_id=? AND (ancestor_path=? OR ancestor_path LIKE ?)
-            """, (USER_ID, str(cid), f"%.{cid}%")).fetchone()
-
             raw = json.loads(raw_json_str or "{}")
             is_liked = bool(raw.get("reaction"))
             link = f"{url.rstrip('/')}/comment/{cid}" if url else ""
@@ -432,8 +457,8 @@ def load_post_comments_data(conn, pub_subdomain):
                 "liked": is_liked,
             }
 
-            if your_reply:
-                c["your_reply"] = your_reply[1] or ""
+            if _replied_under(own_replies, cid):
+                c["your_reply"] = _own_reply_body_under(own_replies, cid)
                 responded_list.append(c)
                 continue
 
@@ -455,31 +480,43 @@ def load_post_comments_data(conn, pub_subdomain):
     return result
 
 
-def load_notes_data(conn):
+NOTES_RENDER_LIMIT = 200
+
+
+def load_notes_data(conn, limit=NOTES_RENDER_LIMIT):
     """Return your authored Notes: standalone notes and replies you made in others' note threads.
     Notes are stored in the comments table with post_id/pub_subdomain NULL, since they
-    aren't tied to a post; populated by `scraper.py sync` via sync_my_notes()."""
-    rows = conn.execute("""
-        SELECT id, body, date, ancestor_path, raw_json
-        FROM comments
-        WHERE user_id=? AND post_id IS NULL AND pub_subdomain IS NULL
-        ORDER BY date DESC
-    """, (USER_ID,)).fetchall()
+    aren't tied to a post; populated by `scraper.py sync` via sync_my_notes().
 
-    standalone = []
-    thread_replies = []
-    for cid, body, date, ancestor_path, raw_json_str in rows:
-        raw = json.loads(raw_json_str or "{}")
-        note = {
-            "id": cid,
-            "body": body or "",
-            "date": (date or "")[:10],
-            "raw_date": date or "",
-            "link": f"https://substack.com/@{HANDLE}/note/c-{cid}",
-            "reaction_count": raw.get("reaction_count") or 0,
-            "restacks": raw.get("restacks") or 0,
-        }
-        (thread_replies if ancestor_path else standalone).append(note)
+    Capped at `limit` most-recent rows per section — with history fully backfilled
+    this table can hold thousands of rows, and rendering all of them into every
+    page load (regardless of which tab is active) is what made the page huge and
+    slow. Only the most recent `limit` of each render; older ones stay in the DB."""
+
+    def fetch(ancestor_clause):
+        rows = conn.execute(f"""
+            SELECT id, body, date, raw_json
+            FROM comments
+            WHERE user_id=? AND post_id IS NULL AND pub_subdomain IS NULL AND {ancestor_clause}
+            ORDER BY date DESC
+            LIMIT ?
+        """, (USER_ID, limit)).fetchall()
+        notes = []
+        for cid, body, date, raw_json_str in rows:
+            raw = json.loads(raw_json_str or "{}")
+            notes.append({
+                "id": cid,
+                "body": body or "",
+                "date": (date or "")[:10],
+                "raw_date": date or "",
+                "link": f"https://substack.com/@{HANDLE}/note/c-{cid}",
+                "reaction_count": raw.get("reaction_count") or 0,
+                "restacks": raw.get("restacks") or 0,
+            })
+        return notes
+
+    standalone = fetch("(ancestor_path IS NULL OR ancestor_path = '')")
+    thread_replies = fetch("ancestor_path IS NOT NULL AND ancestor_path != ''")
 
     return {"standalone": standalone, "thread_replies": thread_replies}
 
@@ -997,7 +1034,15 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
       font-family: 'DM Sans', sans-serif;
     }}
     input[type="text"]:focus, input[type="date"]:focus {{ outline: none; border-color: #1F6FA8 !important; box-shadow: 0 0 0 2px rgba(31,111,168,0.12); }}
-    @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
+    @keyframes envelope-fly {{
+      0%   {{ transform: translate(-40px, 0) rotate(0deg); opacity: 0; }}
+      10%  {{ opacity: 1; }}
+      40%  {{ transform: translate(80px, 0) rotate(0deg); }}
+      55%  {{ transform: translate(115px, -50px) rotate(180deg); }}
+      70%  {{ transform: translate(150px, 0) rotate(360deg); }}
+      90%  {{ opacity: 1; }}
+      100% {{ transform: translate(240px, 0) rotate(360deg); opacity: 0; }}
+    }}
   </style>
 </head>
 <body>
@@ -1042,7 +1087,9 @@ def render_html(items, stats, all_posts_data=None, active_tab="replies", all_pub
   </div>
 
   <div id="page-loading" style="display:none; position:fixed; inset:0; background:rgba(242,248,253,0.85); z-index:9999; display:none; align-items:center; justify-content:center; flex-direction:column; gap:10px;">
-    <div style="width:28px; height:28px; border:3px solid #D8ECF8; border-top-color:#1F6FA8; border-radius:50%; animation:spin 0.7s linear infinite;"></div>
+    <div style="width:240px; height:90px; overflow:hidden; position:relative;">
+      <div style="position:absolute; top:55px; left:0; font-size:28px; line-height:32px; animation:envelope-fly 3s ease-in-out infinite;">✉️</div>
+    </div>
     <div style="font-size:0.85rem; color:#666;">Reloading…</div>
   </div>
 

--- a/scraper.py
+++ b/scraper.py
@@ -557,6 +557,90 @@ def sync_activity_feed(conn, target=UNRESPONDED_TARGET, after_cursor=None, set_l
     return new_items, new_unresponded, oldest_ts
 
 
+def sync_my_notes(conn):
+    """
+    Fetch all Notes authored by the user via the profile feed API
+    (https://substack.com/api/v1/reader/feed/profile/{USER_ID}), storing each
+    in the comments table (post_id/pub_subdomain NULL, since notes aren't tied
+    to a post).
+
+    Uses a watermark (my_notes_last_synced_at) so repeat runs walk the feed
+    newest-first and stop as soon as they reach an already-synced note —
+    normally just page 1. The very first run has no watermark, so it walks
+    the full history instead, persisting progress (my_notes_backfill_cursor)
+    after each page so an interrupted backfill can resume where it left off.
+    """
+    url = f"https://substack.com/api/v1/reader/feed/profile/{USER_ID}"
+    last_synced_at = get_state(conn, "my_notes_last_synced_at")
+    backfilling = last_synced_at is None
+    cursor = get_state(conn, "my_notes_backfill_cursor") if backfilling else None
+
+    newest_seen = None
+    total_stored = 0
+    total_updated = 0
+    page = 0
+    reached_watermark = False
+
+    print(f"{ts()} Checking for new Notes...")
+
+    while True:
+        data = get(url, {"cursor": cursor} if cursor else None)
+        items = data.get("items", [])
+        if not items:
+            break
+        page += 1
+
+        for item in items:
+            if item.get("context", {}).get("type") != "note":
+                continue  # skip restacks and other feed entry types
+            c = item.get("comment") or {}
+            if not c.get("id"):
+                continue
+
+            note_date = c.get("date", "")
+            if newest_seen is None or note_date > newest_seen:
+                newest_seen = note_date
+            if last_synced_at and note_date <= last_synced_at:
+                reached_watermark = True
+                break
+
+            note_url = f"https://substack.com/@{HANDLE}/note/c-{c['id']}"
+            existing = conn.execute("SELECT 1 FROM comments WHERE id=?", (c["id"],)).fetchone()
+            if existing:
+                conn.execute("UPDATE comments SET raw_json=?, body=? WHERE id=?",
+                             (json.dumps(c), c.get("body", ""), c["id"]))
+                total_updated += 1
+            else:
+                _store_comment(conn, c, pub_subdomain=None, post_id=None,
+                               post_title="Note", post_url=note_url)
+                total_stored += 1
+
+        conn.commit()
+        print(f"{ts()}   page {page} — {total_stored} new, {total_updated} refreshed so far")
+
+        if reached_watermark:
+            break
+
+        next_cursor = data.get("nextCursor")
+        if not next_cursor:
+            break
+        cursor = next_cursor
+        if backfilling:
+            set_state(conn, "my_notes_backfill_cursor", cursor)
+            conn.commit()
+        time.sleep(1)
+
+    if newest_seen and (last_synced_at is None or newest_seen > last_synced_at):
+        set_state(conn, "my_notes_last_synced_at", newest_seen)
+        conn.commit()
+
+    total_notes = conn.execute("""
+        SELECT COUNT(*) FROM comments WHERE user_id=? AND post_id IS NULL AND pub_subdomain IS NULL
+    """, (USER_ID,)).fetchone()[0]
+    print(f"{ts()} Notes sync done: {total_stored} new, {total_updated} refreshed, {total_notes} total notes in DB")
+    return total_stored
+
+
 def _store_comment(conn, c, pub_subdomain, post_id, post_title, post_url):
     if not c or not c.get("id"):
         return
@@ -1028,7 +1112,7 @@ def main():
             args.discard(as_of_date)
 
     if not args:
-        print("Usage: python scraper.py [sync] [report] [load-post --pub X] [sync-posts --pub X] [--as-of YYYY-MM-DD]")
+        print("Usage: python scraper.py [sync] [report] [my-notes] [load-post --pub X] [sync-posts --pub X] [--as-of YYYY-MM-DD]")
         sys.exit(0)
 
     with sqlite3.connect(DB_PATH, timeout=30) as conn:
@@ -1054,6 +1138,9 @@ def main():
                 sys.exit(1)
             refresh_post_comments(conn, pub)
 
+        if "my-notes" in args:
+            sync_my_notes(conn)
+
         if "sync" in args:
             if as_of_date:
                 print(f"{ts()} Starting sync (--as-of {as_of_date})...")
@@ -1066,7 +1153,10 @@ def main():
                 time.sleep(3)
                 still_unresponded += recheck_note_replies(conn)
 
-                # Step 2: always fetch a full target of new replies from new activity
+                # Step 2: fetch any Notes written since the last sync
+                sync_my_notes(conn)
+
+                # Step 3: always fetch a full target of new replies from new activity
                 new_items, new_unresponded = 0, 0
                 oldest_ts = None
                 new_items, new_unresponded, oldest_ts = sync_activity_feed(
@@ -1075,14 +1165,23 @@ def main():
                     set_last_synced=True,
                 )
 
-                # Step 3: backfill older history if we haven't fetched everything
+                # Step 4: backfill older history if we haven't fetched everything
                 if new_unresponded < count:
                     remaining = count - new_unresponded
                     oldest_cursor = get_state(conn, "backfill_cursor")
                     if oldest_cursor:
                         print(f"{ts()} Backfilling — need {remaining} more replies...")
-                        sync_activity_feed(conn, target=remaining, after_cursor=oldest_cursor,
-                                           set_last_synced=False, stop_on_empty=True)
+                        _, backfill_unresponded, _ = sync_activity_feed(
+                            conn, target=remaining, after_cursor=oldest_cursor,
+                            set_last_synced=False, stop_on_empty=True)
+                        new_unresponded += backfill_unresponded
+
+                # Substack's feed caps how far a single pagination walk can go, so a
+                # requested count can go unmet even with no error — call that out
+                # explicitly rather than let it pass silently.
+                if new_unresponded < count:
+                    print(f"{ts()} Only found {new_unresponded} of {count} requested replies — "
+                          f"reached the end of available history for this pass. Run sync again to continue further back.")
 
                 conn.execute("INSERT INTO sync_log VALUES (?,?,?)",
                              (datetime.now(timezone.utc).isoformat(), "activity_feed", new_items))

--- a/scraper.py
+++ b/scraper.py
@@ -84,6 +84,7 @@ def init_db(conn):
             target_post_id INTEGER,
             is_new INTEGER,
             is_responded INTEGER DEFAULT 0,
+            is_archived INTEGER DEFAULT 0,
             raw_json TEXT
         );
 
@@ -128,11 +129,15 @@ def init_db(conn):
     # WAL mode: allows concurrent reads and writes between Flask and the scraper subprocess
     conn.execute("PRAGMA journal_mode=WAL")
 
-    # Migrate existing DB: add is_responded if it doesn't exist yet
-    try:
-        conn.execute("ALTER TABLE activity_items ADD COLUMN is_responded INTEGER DEFAULT 0")
-    except Exception:
-        pass  # column already exists
+    # Migrate existing DB: add columns introduced after the original CREATE TABLE
+    for ddl in (
+        "ALTER TABLE activity_items ADD COLUMN is_responded INTEGER DEFAULT 0",
+        "ALTER TABLE activity_items ADD COLUMN is_archived INTEGER DEFAULT 0",
+    ):
+        try:
+            conn.execute(ddl)
+        except Exception:
+            pass  # column already exists
 
     conn.commit()
 

--- a/scraper.py
+++ b/scraper.py
@@ -557,38 +557,54 @@ def sync_activity_feed(conn, target=UNRESPONDED_TARGET, after_cursor=None, set_l
     return new_items, new_unresponded, oldest_ts
 
 
-def sync_my_notes(conn):
+def sync_my_notes(conn, target=None, after_cursor=None, set_last_synced=None, stop_on_empty=False):
     """
-    Fetch all Notes authored by the user via the profile feed API
+    Fetch Notes authored by the user via the profile feed API
     (https://substack.com/api/v1/reader/feed/profile/{USER_ID}), storing each
     in the comments table (post_id/pub_subdomain NULL, since notes aren't tied
     to a post).
 
-    Uses a watermark (my_notes_last_synced_at) so repeat runs walk the feed
-    newest-first and stop as soon as they reach an already-synced note —
-    normally just page 1. The very first run has no watermark, so it walks
-    the full history instead, persisting progress (my_notes_backfill_cursor)
-    after each page so an interrupted backfill can resume where it left off.
+    Mirrors sync_activity_feed's two-cursor design:
+      - Forward pass (after_cursor=None): walks from the newest note down,
+        stopping at `my_notes_last_synced_at` (or `target`, or feed end).
+        Advances that watermark as it goes.
+      - Backfill pass (after_cursor=persisted my_notes_backfill_cursor):
+        resumes further back into history, capped at `target` per call so a
+        single sync can't walk unbounded — call again to go further back.
+
+    Both passes persist my_notes_backfill_cursor as they page, but only ever
+    move it further into the past. The cursor itself is an opaque token (not
+    a timestamp we can compare, unlike activity feed's), so a comparable date
+    (my_notes_backfill_anchor_date) is tracked alongside it purely to guard
+    direction — otherwise a quick forward pass could clobber deep backfill
+    progress from an earlier run.
+
+    Returns total notes stored/updated this call (for the caller to decide
+    whether a further backfill pass is needed).
     """
     url = f"https://substack.com/api/v1/reader/feed/profile/{USER_ID}"
     last_synced_at = get_state(conn, "my_notes_last_synced_at")
-    backfilling = last_synced_at is None
-    cursor = get_state(conn, "my_notes_backfill_cursor") if backfilling else None
+    should_update_last_synced = set_last_synced if set_last_synced is not None else (after_cursor is None)
 
+    cursor = after_cursor
     newest_seen = None
     total_stored = 0
     total_updated = 0
     page = 0
-    reached_watermark = False
+    consecutive_empty = 0
+    done = False
 
-    print(f"{ts()} Checking for new Notes...")
+    print(f"{ts()} Checking for Notes...")
 
-    while True:
+    while not done:
         data = get(url, {"cursor": cursor} if cursor else None)
         items = data.get("items", [])
         if not items:
+            print(f"{ts()}   Feed exhausted.")
             break
         page += 1
+        stored_this_page = 0
+        oldest_this_page = None
 
         for item in items:
             if item.get("context", {}).get("type") != "note":
@@ -598,10 +614,18 @@ def sync_my_notes(conn):
                 continue
 
             note_date = c.get("date", "")
-            if newest_seen is None or note_date > newest_seen:
+            if note_date and (oldest_this_page is None or note_date < oldest_this_page):
+                oldest_this_page = note_date
+            if note_date and (newest_seen is None or note_date > newest_seen):
                 newest_seen = note_date
-            if last_synced_at and note_date <= last_synced_at:
-                reached_watermark = True
+
+            # Stop when we reach already-synced territory (forward pass only).
+            # Compares against the watermark as it stood at the *start* of this
+            # call — never the accumulator above, or the very first item fetched
+            # would immediately look "already synced" against itself.
+            if after_cursor is None and last_synced_at and note_date and note_date <= last_synced_at:
+                print(f"{ts()}   Reached last sync point.")
+                done = True
                 break
 
             note_url = f"https://substack.com/@{HANDLE}/note/c-{c['id']}"
@@ -614,23 +638,47 @@ def sync_my_notes(conn):
                 _store_comment(conn, c, pub_subdomain=None, post_id=None,
                                post_title="Note", post_url=note_url)
                 total_stored += 1
+            stored_this_page += 1
+
+            if target is not None and (total_stored + total_updated) >= target:
+                print(f"{ts()}   Hit target of {target} notes.")
+                done = True
+                break
 
         conn.commit()
         print(f"{ts()}   page {page} — {total_stored} new, {total_updated} refreshed so far")
 
-        if reached_watermark:
+        if done:
             break
+
+        if stop_on_empty:
+            if stored_this_page == 0:
+                consecutive_empty += 1
+                if consecutive_empty >= 3:
+                    print(f"{ts()}   3 consecutive empty pages — fully synced to this point.")
+                    break
+            else:
+                consecutive_empty = 0
 
         next_cursor = data.get("nextCursor")
         if not next_cursor:
+            print(f"{ts()}   No more pages.")
             break
         cursor = next_cursor
-        if backfilling:
-            set_state(conn, "my_notes_backfill_cursor", cursor)
-            conn.commit()
+
+        # Persist backfill progress — only move backward (never forward).
+        if oldest_this_page:
+            current_anchor = get_state(conn, "my_notes_backfill_anchor_date")
+            if not current_anchor or oldest_this_page < current_anchor:
+                set_state(conn, "my_notes_backfill_cursor", cursor)
+                set_state(conn, "my_notes_backfill_anchor_date", oldest_this_page)
+        # Advance the forward watermark as we go, so a killed sync doesn't rescan from the top
+        if after_cursor is None and should_update_last_synced and newest_seen:
+            set_state(conn, "my_notes_last_synced_at", newest_seen)
+        conn.commit()
         time.sleep(1)
 
-    if newest_seen and (last_synced_at is None or newest_seen > last_synced_at):
+    if after_cursor is None and should_update_last_synced and newest_seen:
         set_state(conn, "my_notes_last_synced_at", newest_seen)
         conn.commit()
 
@@ -638,7 +686,7 @@ def sync_my_notes(conn):
         SELECT COUNT(*) FROM comments WHERE user_id=? AND post_id IS NULL AND pub_subdomain IS NULL
     """, (USER_ID,)).fetchone()[0]
     print(f"{ts()} Notes sync done: {total_stored} new, {total_updated} refreshed, {total_notes} total notes in DB")
-    return total_stored
+    return total_stored + total_updated
 
 
 def _store_comment(conn, c, pub_subdomain, post_id, post_title, post_url):
@@ -1112,7 +1160,7 @@ def main():
             args.discard(as_of_date)
 
     if not args:
-        print("Usage: python scraper.py [sync] [report] [my-notes] [load-post --pub X] [sync-posts --pub X] [--as-of YYYY-MM-DD]")
+        print("Usage: python scraper.py [sync] [report] [my-notes] [load-post --pub X] [sync-posts --pub X] [--as-of YYYY-MM-DD] [--count N]")
         sys.exit(0)
 
     with sqlite3.connect(DB_PATH, timeout=30) as conn:
@@ -1139,7 +1187,14 @@ def main():
             refresh_post_comments(conn, pub)
 
         if "my-notes" in args:
-            sync_my_notes(conn)
+            notes_found = sync_my_notes(conn, target=count, set_last_synced=True)
+            if notes_found < count:
+                notes_cursor = get_state(conn, "my_notes_backfill_cursor")
+                if notes_cursor:
+                    remaining = count - notes_found
+                    print(f"{ts()} Backfilling Notes — need {remaining} more...")
+                    sync_my_notes(conn, target=remaining, after_cursor=notes_cursor,
+                                  set_last_synced=False, stop_on_empty=True)
 
         if "sync" in args:
             if as_of_date:
@@ -1153,8 +1208,16 @@ def main():
                 time.sleep(3)
                 still_unresponded += recheck_note_replies(conn)
 
-                # Step 2: fetch any Notes written since the last sync
-                sync_my_notes(conn)
+                # Step 2: fetch Notes — new since last sync, then backfill further
+                # into history if we haven't caught up to `count` yet this pass
+                notes_found = sync_my_notes(conn, target=count, set_last_synced=True)
+                if notes_found < count:
+                    notes_cursor = get_state(conn, "my_notes_backfill_cursor")
+                    if notes_cursor:
+                        remaining = count - notes_found
+                        print(f"{ts()} Backfilling Notes — need {remaining} more...")
+                        sync_my_notes(conn, target=remaining, after_cursor=notes_cursor,
+                                      set_last_synced=False, stop_on_empty=True)
 
                 # Step 3: always fetch a full target of new replies from new activity
                 new_items, new_unresponded = 0, 0


### PR DESCRIPTION
## Summary
- Adds `sync_my_notes()` to fetch every Note authored via the profile feed API (`reader/feed/profile/{USER_ID}`), stored in the `comments` table
- Uses a watermark (`my_notes_last_synced_at`) for incremental syncs; resumable backfill cursor (`my_notes_backfill_cursor`) for the initial full-history pull
- Wired into the existing `sync` command, also runnable standalone via `python scraper.py my-notes`
- New Notes tab in the dashboard: standalone notes and thread replies shown separately, same search/filter behavior as other tabs

Closes #64

## Test plan
- [x] `python check.py` — all 9 checks pass
- [x] `load_notes_data()` smoke-tested against live DB (823 standalone notes, 6050 thread replies)
- [ ] Manual click-through of the new Notes tab in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)