### PR TITLE
Track subscribers across all publications in a separate DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 replies.db*
+subscribers.db*
 .env
 config.py
 *.bak

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -214,9 +214,14 @@ Recheck runs at the start of every sync. It re-examines items previously marked 
 **Where:** `subscribers.py` → `import_screenshot_rows()`
 
 ### 8.4 Merge, don't overwrite, on upsert
-**What:** Upserting by email only overwrites a field when the new value is non-empty and different, so a partial screenshot row never blanks out richer CSV fields (expiry, first_payment_at), and a later CSV re-import never erases a `quality_stars` value that only ever came from a screenshot.
+**What:** Upserting by (email, publication) only overwrites a field when the new value is non-empty and different, so a partial screenshot row never blanks out richer CSV fields (expiry, first_payment_at), and a later CSV re-import never erases a `quality_stars` value that only ever came from a screenshot.
 **Status:** ✅
 **Where:** `subscribers.py` → `upsert()`
+
+### 8.5 Track multiple publications and dedupe across them
+**What:** Alyssa runs three Substacks (alyssafuward, thehartstudio, createwithalyssa) with overlapping subscribers. Each row is keyed by (email, publication), so the same person subscribed to two publications gets two rows. `python subscribers.py --summary` prints per-publication counts, the deduped unique total across all publications, and pairwise/all-publication overlap counts.
+**Status:** ✅
+**Where:** `subscribers.py` → `dedupe_summary()`, `print_dedupe_summary()`; publication is inferred from the CSV filename (`email_list.<publication>.csv`)
 
 ---
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -196,6 +196,30 @@ Recheck runs at the start of every sync. It re-examines items previously marked 
 
 ---
 
+## 8. Subscriber Tracking
+
+### 8.1 Separate subscriber DB
+**What:** Track the Substack subscriber list (email, plan, signup date, active/expiry status) in its own SQLite DB, kept apart from `replies.db` since comments and subscribers are different entities with no shared key (subscriber CSV exports have no display name).
+**Status:** ✅
+**Where:** `subscribers.py` → `subscribers.db` (gitignored, local only, same pattern as `replies.db`)
+
+### 8.2 Import full CSV export
+**What:** Import Substack's subscriber CSV export (Settings → Subscribers → export) — email, active_subscription, expiry, plan, email_disabled, created_at, first_payment_at.
+**Status:** ✅
+**Where:** `subscribers.py` → `import_csv()`; run as `python subscribers.py <path-to-csv>`
+
+### 8.3 Top up from screenshots between exports
+**What:** Add or update subscriber rows from data Claude reads off a screenshot of the Substack subscriber dashboard (email, plan tag, star/quality rating, signup date — no expiry or first_payment_at, since the dashboard view doesn't show those).
+**Status:** ✅
+**Where:** `subscribers.py` → `import_screenshot_rows()`
+
+### 8.4 Merge, don't overwrite, on upsert
+**What:** Upserting by email only overwrites a field when the new value is non-empty and different, so a partial screenshot row never blanks out richer CSV fields (expiry, first_payment_at), and a later CSV re-import never erases a `quality_stars` value that only ever came from a screenshot.
+**Status:** ✅
+**Where:** `subscribers.py` → `upsert()`
+
+---
+
 ## Open bugs summary
 
 | ID | Description | Severity |

--- a/subscribers.py
+++ b/subscribers.py
@@ -1,27 +1,35 @@
-"""Subscriber list tracker — separate DB from replies.db (see issue #67).
+"""Subscriber list tracker across all publications — separate DB from replies.db (see issue #67).
+
+Alyssa runs three Substacks (alyssafuward, thehartstudio, createwithalyssa) with
+overlapping subscribers. This tracks each publication's list and lets you see
+the deduped total and per-pair overlap.
 
 Two ways data comes in:
-  - Full CSV export from Substack (Settings -> Subscribers -> export): email,
-    active_subscription, expiry, plan, email_disabled, created_at, first_payment_at.
-    No display name.
+  - Full CSV export from Substack (Settings -> Subscribers -> export), named
+    email_list.<publication>.csv: email, active_subscription, expiry, plan,
+    email_disabled, created_at, first_payment_at. No display name.
   - Screenshot of the Substack subscriber dashboard, read by Claude: email,
     plan tag (Free / Yearly Paid / Monthly Paid), star rating, signup date.
     Partial — no expiry/first_payment_at.
 
-Upserts merge fields rather than overwrite, so a partial screenshot row never
-blows away richer data from a CSV import, and a later CSV re-import never
-erases a star rating that only ever came from a screenshot.
+A person subscribed to multiple publications gets one row per (email,
+publication) pair. Upserts merge fields rather than overwrite, so a partial
+screenshot row never blows away richer data from a CSV import, and a later
+CSV re-import never erases a star rating that only ever came from a screenshot.
 """
 
 import csv
+import re
 import sqlite3
 from datetime import datetime, timezone
+from itertools import combinations
 
 DB_PATH = "subscribers.db"
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS subscribers (
-    email TEXT PRIMARY KEY,
+    email TEXT NOT NULL,
+    publication TEXT NOT NULL,
     name TEXT,
     active_subscription TEXT,
     expiry TEXT,
@@ -32,7 +40,8 @@ CREATE TABLE IF NOT EXISTS subscribers (
     quality_stars INTEGER,
     source TEXT,
     first_seen_at TEXT,
-    last_updated_at TEXT
+    last_updated_at TEXT,
+    PRIMARY KEY (email, publication)
 );
 """
 
@@ -48,11 +57,13 @@ def get_conn(db_path=DB_PATH):
     return conn
 
 
-def upsert(conn, email, source, **fields):
-    """Insert or merge a subscriber row. Only non-None fields overwrite existing values."""
+def upsert(conn, email, publication, source, **fields):
+    """Insert or merge a subscriber row. Only non-None/non-empty fields overwrite existing values."""
     email = email.strip().lower()
     now = datetime.now(timezone.utc).isoformat()
-    cur = conn.execute("SELECT * FROM subscribers WHERE email = ?", (email,))
+    cur = conn.execute(
+        "SELECT * FROM subscribers WHERE email = ? AND publication = ?", (email, publication)
+    )
     existing = cur.fetchone()
     col_names = [d[0] for d in cur.description] if existing else None
 
@@ -60,9 +71,9 @@ def upsert(conn, email, source, **fields):
         row = {f: fields.get(f) for f in FIELDS}
         conn.execute(
             f"""INSERT INTO subscribers
-                (email, {", ".join(FIELDS)}, source, first_seen_at, last_updated_at)
-                VALUES (?, {", ".join("?" for _ in FIELDS)}, ?, ?, ?)""",
-            (email, *[row[f] for f in FIELDS], source, now, now),
+                (email, publication, {", ".join(FIELDS)}, source, first_seen_at, last_updated_at)
+                VALUES (?, ?, {", ".join("?" for _ in FIELDS)}, ?, ?, ?)""",
+            (email, publication, *[row[f] for f in FIELDS], source, now, now),
         )
         return "inserted"
 
@@ -78,20 +89,32 @@ def upsert(conn, email, source, **fields):
         existing_dict["last_updated_at"] = now
         conn.execute(
             f"""UPDATE subscribers SET {", ".join(f"{f} = ?" for f in FIELDS)},
-                source = ?, last_updated_at = ? WHERE email = ?""",
-            (*[existing_dict[f] for f in FIELDS], source, now, email),
+                source = ?, last_updated_at = ? WHERE email = ? AND publication = ?""",
+            (*[existing_dict[f] for f in FIELDS], source, now, email, publication),
         )
         return "updated"
     return "unchanged"
 
 
-def import_csv(conn, csv_path, source="csv_export"):
+def publication_from_filename(csv_path):
+    """email_list.<publication>.csv -> <publication>"""
+    m = re.search(r"email_list\.([^.]+)\.csv$", csv_path)
+    if not m:
+        raise ValueError(
+            f"Can't infer publication from {csv_path!r} — pass publication= explicitly"
+        )
+    return m.group(1)
+
+
+def import_csv(conn, csv_path, publication=None, source="csv_export"):
+    publication = publication or publication_from_filename(csv_path)
     counts = {"inserted": 0, "updated": 0, "unchanged": 0}
     with open(csv_path, newline="") as f:
         for row in csv.DictReader(f):
             result = upsert(
                 conn,
                 row["email"],
+                publication,
                 source,
                 active_subscription=row.get("active_subscription"),
                 expiry=row.get("expiry"),
@@ -102,16 +125,17 @@ def import_csv(conn, csv_path, source="csv_export"):
             )
             counts[result] += 1
     conn.commit()
-    return counts
+    return publication, counts
 
 
-def import_screenshot_rows(conn, rows, source="screenshot"):
+def import_screenshot_rows(conn, rows, publication, source="screenshot"):
     """rows: list of dicts with at least 'email'; optional plan, quality_stars, created_at, name."""
     counts = {"inserted": 0, "updated": 0, "unchanged": 0}
     for row in rows:
         result = upsert(
             conn,
             row["email"],
+            publication,
             source,
             name=row.get("name"),
             plan=row.get("plan"),
@@ -123,13 +147,59 @@ def import_screenshot_rows(conn, rows, source="screenshot"):
     return counts
 
 
+def dedupe_summary(conn):
+    """Per-publication counts, deduped total across all publications, and pairwise overlaps."""
+    pubs = [r[0] for r in conn.execute("SELECT DISTINCT publication FROM subscribers ORDER BY 1")]
+    by_pub = {
+        p: set(
+            r[0]
+            for r in conn.execute("SELECT email FROM subscribers WHERE publication = ?", (p,))
+        )
+        for p in pubs
+    }
+    total_unique = len(set.union(*by_pub.values())) if by_pub else 0
+    total_with_dupes = sum(len(s) for s in by_pub.values())
+    overlaps = {
+        (a, b): len(by_pub[a] & by_pub[b]) for a, b in combinations(pubs, 2)
+    }
+    all_overlap = len(set.intersection(*by_pub.values())) if len(by_pub) > 1 else None
+    return {
+        "per_publication": {p: len(s) for p, s in by_pub.items()},
+        "total_with_duplicates": total_with_dupes,
+        "total_unique": total_unique,
+        "pairwise_overlap": overlaps,
+        "all_publications_overlap": all_overlap,
+    }
+
+
+def print_dedupe_summary(conn):
+    s = dedupe_summary(conn)
+    print("Per-publication subscriber counts:")
+    for pub, count in s["per_publication"].items():
+        print(f"  {pub}: {count}")
+    print(f"\nSum with duplicates: {s['total_with_duplicates']}")
+    print(f"Unique total: {s['total_unique']}")
+    print("\nPairwise overlap:")
+    for (a, b), n in s["pairwise_overlap"].items():
+        print(f"  {a} & {b}: {n}")
+    if s["all_publications_overlap"] is not None:
+        print(f"\nIn all publications: {s['all_publications_overlap']}")
+
+
 if __name__ == "__main__":
     import sys
 
-    if len(sys.argv) != 2:
-        print("Usage: python subscribers.py <path-to-email_list-csv>")
+    if len(sys.argv) == 2 and sys.argv[1] == "--summary":
+        print_dedupe_summary(get_conn())
+    elif len(sys.argv) == 2:
+        conn = get_conn()
+        publication, counts = import_csv(conn, sys.argv[1])
+        total = conn.execute(
+            "SELECT COUNT(*) FROM subscribers WHERE publication = ?", (publication,)
+        ).fetchone()[0]
+        print(f"[{publication}] {counts} — total in db for this publication: {total}")
+    else:
+        print("Usage:")
+        print("  python subscribers.py <path-to-email_list-csv>   (publication inferred from filename)")
+        print("  python subscribers.py --summary                  (deduped counts + overlaps)")
         sys.exit(1)
-    conn = get_conn()
-    counts = import_csv(conn, sys.argv[1])
-    total = conn.execute("SELECT COUNT(*) FROM subscribers").fetchone()[0]
-    print(f"{counts} — total subscribers in db: {total}")

--- a/subscribers.py
+++ b/subscribers.py
@@ -1,0 +1,135 @@
+"""Subscriber list tracker — separate DB from replies.db (see issue #67).
+
+Two ways data comes in:
+  - Full CSV export from Substack (Settings -> Subscribers -> export): email,
+    active_subscription, expiry, plan, email_disabled, created_at, first_payment_at.
+    No display name.
+  - Screenshot of the Substack subscriber dashboard, read by Claude: email,
+    plan tag (Free / Yearly Paid / Monthly Paid), star rating, signup date.
+    Partial — no expiry/first_payment_at.
+
+Upserts merge fields rather than overwrite, so a partial screenshot row never
+blows away richer data from a CSV import, and a later CSV re-import never
+erases a star rating that only ever came from a screenshot.
+"""
+
+import csv
+import sqlite3
+from datetime import datetime, timezone
+
+DB_PATH = "subscribers.db"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS subscribers (
+    email TEXT PRIMARY KEY,
+    name TEXT,
+    active_subscription TEXT,
+    expiry TEXT,
+    plan TEXT,
+    email_disabled TEXT,
+    created_at TEXT,
+    first_payment_at TEXT,
+    quality_stars INTEGER,
+    source TEXT,
+    first_seen_at TEXT,
+    last_updated_at TEXT
+);
+"""
+
+FIELDS = [
+    "name", "active_subscription", "expiry", "plan", "email_disabled",
+    "created_at", "first_payment_at", "quality_stars",
+]
+
+
+def get_conn(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    conn.execute(SCHEMA)
+    return conn
+
+
+def upsert(conn, email, source, **fields):
+    """Insert or merge a subscriber row. Only non-None fields overwrite existing values."""
+    email = email.strip().lower()
+    now = datetime.now(timezone.utc).isoformat()
+    cur = conn.execute("SELECT * FROM subscribers WHERE email = ?", (email,))
+    existing = cur.fetchone()
+    col_names = [d[0] for d in cur.description] if existing else None
+
+    if existing is None:
+        row = {f: fields.get(f) for f in FIELDS}
+        conn.execute(
+            f"""INSERT INTO subscribers
+                (email, {", ".join(FIELDS)}, source, first_seen_at, last_updated_at)
+                VALUES (?, {", ".join("?" for _ in FIELDS)}, ?, ?, ?)""",
+            (email, *[row[f] for f in FIELDS], source, now, now),
+        )
+        return "inserted"
+
+    existing_dict = dict(zip(col_names, existing))
+    changed = False
+    for f in FIELDS:
+        new_val = fields.get(f)
+        if new_val is not None and new_val != "" and str(new_val) != str(existing_dict.get(f)):
+            existing_dict[f] = new_val
+            changed = True
+    if changed:
+        existing_dict["source"] = source
+        existing_dict["last_updated_at"] = now
+        conn.execute(
+            f"""UPDATE subscribers SET {", ".join(f"{f} = ?" for f in FIELDS)},
+                source = ?, last_updated_at = ? WHERE email = ?""",
+            (*[existing_dict[f] for f in FIELDS], source, now, email),
+        )
+        return "updated"
+    return "unchanged"
+
+
+def import_csv(conn, csv_path, source="csv_export"):
+    counts = {"inserted": 0, "updated": 0, "unchanged": 0}
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            result = upsert(
+                conn,
+                row["email"],
+                source,
+                active_subscription=row.get("active_subscription"),
+                expiry=row.get("expiry"),
+                plan=row.get("plan"),
+                email_disabled=row.get("email_disabled"),
+                created_at=row.get("created_at"),
+                first_payment_at=row.get("first_payment_at"),
+            )
+            counts[result] += 1
+    conn.commit()
+    return counts
+
+
+def import_screenshot_rows(conn, rows, source="screenshot"):
+    """rows: list of dicts with at least 'email'; optional plan, quality_stars, created_at, name."""
+    counts = {"inserted": 0, "updated": 0, "unchanged": 0}
+    for row in rows:
+        result = upsert(
+            conn,
+            row["email"],
+            source,
+            name=row.get("name"),
+            plan=row.get("plan"),
+            quality_stars=row.get("quality_stars"),
+            created_at=row.get("created_at"),
+        )
+        counts[result] += 1
+    conn.commit()
+    return counts
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python subscribers.py <path-to-email_list-csv>")
+        sys.exit(1)
+    conn = get_conn()
+    counts = import_csv(conn, sys.argv[1])
+    total = conn.execute("SELECT COUNT(*) FROM subscribers").fetchone()[0]
+    print(f"{counts} — total subscribers in db: {total}")


### PR DESCRIPTION
## Summary
- Adds `subscribers.py`, a standalone importer for a new `subscribers.db` (gitignored, separate from `replies.db`) that tracks the Substack subscriber list — email, plan, signup date, active/expiry status.
- Rows keyed by `(email, publication)` so the same person subscribed to multiple newsletters (alyssafuward, thehartstudio, createwithalyssa) gets one row per publication.
- Two import paths: `python subscribers.py <csv-path>` for full Substack CSV exports (publication inferred from filename), and `import_screenshot_rows()` for topping up between exports from a screenshot of the subscriber dashboard (adds a `quality_stars` field the CSV export doesn't have).
- Upserts merge fields instead of overwriting, so a partial screenshot row never blanks out CSV-only fields and vice versa.
- `python subscribers.py --summary` prints per-publication counts, the deduped unique total, and pairwise/all-publication overlap counts.
- Not wired into the Flask app at all — no changes to `app.py`, `dashboard.py`, `insights.py`, or `scraper.py`.

Closes #67.

## Test plan
- [x] `python check.py` — all 9 checks pass, unaffected
- [x] Imported real CSV exports for all three publications (893 + 217 + 51 = 1161, 1025 unique)
- [x] Verified screenshot-derived rows merge onto existing CSV rows without duplicating or losing CSV-only fields